### PR TITLE
Fix: Ensure main branch Docker image is tagged as latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,12 +29,16 @@ jobs:
       - name: Set semver and latest tags if release
         id: tagmeta
         run: |
-          if [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "SEMVER=type=semver,pattern=${{ inputs.versionTag }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_call" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "LATEST=type=raw,value=latest" >> $GITHUB_OUTPUT
           else
-            echo "SEMVER=" >> $GITHUB_OUTPUT
             echo "LATEST=" >> $GITHUB_OUTPUT
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "SEMVER=type=semver,pattern=${{ inputs.versionTag }}" >> $GITHUB_OUTPUT
+          else
+            echo "SEMVER=" >> $GITHUB_OUTPUT
           fi
       - name: Extract Docker metadata
         id: meta
@@ -42,7 +46,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.actor }}/${{ github.repository }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
             type=sha
             ${{ steps.tagmeta.outputs.SEMVER }}


### PR DESCRIPTION
The Docker publishing workflow was previously tagging images built from the main branch with the branch name itself (e.g., 'main') instead of the standard 'latest' tag.

This commit modifies the .github/workflows/docker-publish.yml file to:
- Correctly apply the 'latest' tag to images built from the main branch.
- Continue applying the 'latest' tag during release workflows (workflow_call).
- Remove the redundant branch name tag (e.g., 'main') to adhere to standard Docker tagging conventions.

Addresses issue #9.