### PR TITLE
allow forks to publish docker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,8 +24,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Set semver and latest tags if release
         id: tagmeta
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI workflow change**
> 
> - In `./.github/workflows/docker-publish.yml`, update GHCR login to use `username: ${{ github.repository_owner }}` and `password: ${{ secrets.GHCR_PAT }}` instead of `github.actor`/`GITHUB_TOKEN` to allow Docker image publishing from forked PRs.
> - Existing Buildx, metadata, and tag generation steps remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b73bd02075c42a45e4745e535ee438e8e923283f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration in the Docker publishing workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->