### PR TITLE
do not fail on docker push on fork

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Check if PR is from fork
+        id: check-fork
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "is_fork=true" >> $GITHUB_OUTPUT
+            else
+              echo "is_fork=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
       - name: Log in to GitHub Container Registry
+        if: steps.check-fork.outputs.is_fork == 'false'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -55,6 +68,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ steps.check-fork.outputs.is_fork == 'false' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves Docker publish workflow to avoid failures on forked PRs.
> 
> - Adds `check-fork` step to detect if a PR originates from a fork and set `is_fork`
> - Gates `docker/login-action` and `docker/build-push-action` `push` flag on `is_fork == 'false'`
> - Retains existing tag/metadata generation (`semver`/`latest`) behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d6d43fabc1d79aa5acc4be0b624c9c26ca3f21a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->