### PR TITLE
ci: Docker smoke job and manual workflow dispatch

### DIFF
--- a/.changeset/docker-publish-smoke-ci.md
+++ b/.changeset/docker-publish-smoke-ci.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Run Docker image smoke tests in the Docker publish workflow before push, reuse build cache between amd64 smoke and multi-arch publish, and remove the duplicate Docker build from CI. Add `workflow_dispatch` to the Docker publish workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -19,3 +20,33 @@ jobs:
         run: npm ci
       - name: Run tests
         run: npm test
+
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker build
+        run: docker build -t paperless-mcp:ci .
+      - name: Start container
+        run: |
+          docker run -d --name paperless-mcp-smoke \
+            -e PAPERLESS_URL=http://example.test \
+            -e PAPERLESS_API_KEY=ci-smoke-token \
+            -p 3000:3000 \
+            paperless-mcp:ci
+      - name: Wait for HTTP server
+        run: |
+          for i in $(seq 1 30); do
+            code=$(curl -s --max-time 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/mcp || true)
+            if [ "$code" = "405" ]; then
+              echo "Smoke OK: GET /mcp returned 405"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Timeout waiting for 405 from GET /mcp"
+          docker logs paperless-mcp-smoke || true
+          exit 1
+      - name: Cleanup
+        if: always()
+        run: docker rm -f paperless-mcp-smoke || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch:
 
 jobs:
   test:
@@ -20,33 +19,3 @@ jobs:
         run: npm ci
       - name: Run tests
         run: npm test
-
-  docker-smoke:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Docker build
-        run: docker build -t paperless-mcp:ci .
-      - name: Start container
-        run: |
-          docker run -d --name paperless-mcp-smoke \
-            -e PAPERLESS_URL=http://example.test \
-            -e PAPERLESS_API_KEY=ci-smoke-token \
-            -p 3000:3000 \
-            paperless-mcp:ci
-      - name: Wait for HTTP server
-        run: |
-          for i in $(seq 1 30); do
-            code=$(curl -s --max-time 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/mcp || true)
-            if [ "$code" = "405" ]; then
-              echo "Smoke OK: GET /mcp returned 405"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "Timeout waiting for 405 from GET /mcp"
-          docker logs paperless-mcp-smoke || true
-          exit 1
-      - name: Cleanup
-        if: always()
-        run: docker rm -f paperless-mcp-smoke || true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,38 @@ jobs:
             type=sha
             ${{ steps.tagmeta.outputs.SEMVER }}
             ${{ steps.tagmeta.outputs.LATEST }}
+      - name: Build (linux/amd64) for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: paperless-mcp:smoke
+          cache-from: type=gha,scope=paperless-mcp-docker
+          cache-to: type=gha,scope=paperless-mcp-docker,mode=max
+      - name: Smoke test container
+        run: |
+          docker rm -f paperless-mcp-smoke 2>/dev/null || true
+          docker run -d --name paperless-mcp-smoke \
+            -e PAPERLESS_URL=http://example.test \
+            -e PAPERLESS_API_KEY=ci-smoke-token \
+            -p 3000:3000 \
+            paperless-mcp:smoke
+          for i in $(seq 1 30); do
+            code=$(curl -s --max-time 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/mcp || true)
+            if [ "$code" = "405" ]; then
+              echo "Smoke OK: GET /mcp returned 405"
+              docker rm -f paperless-mcp-smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Timeout waiting for 405 from GET /mcp"
+          docker logs paperless-mcp-smoke || true
+          docker rm -f paperless-mcp-smoke
+          exit 1
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -74,3 +106,5 @@ jobs:
           push: ${{ steps.check-fork.outputs.is_fork == 'false' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=paperless-mcp-docker
+          cache-to: type=gha,scope=paperless-mcp-docker,mode=max


### PR DESCRIPTION
Adds a parallel `docker-smoke` job (build image, run with dummy Paperless env, assert GET /mcp returns 405) and `workflow_dispatch` so CI can be run manually.

Dockerfile layout fix is intentionally **not** included; it will ship in a follow-up PR so this change can land and validate against current `main` (expect `docker-smoke` to fail until the image entrypoint/layout is fixed).

Refs: https://github.com/baruchiro/paperless-mcp/issues/75

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow now supports manual triggering for on-demand testing runs.
  * Implemented automated Docker container smoke testing to verify deployment readiness by checking service endpoints.
  * Enhanced cleanup procedures to ensure containers are properly removed after testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->