### PR TITLE
fix: Docker image preserves build/ layout for CLI

### DIFF
--- a/.changeset/docker-build-layout-fix.md
+++ b/.changeset/docker-build-layout-fix.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Preserve the `build/` directory in the production Docker image and run `node build/index.js` so the compiled entrypoint can resolve `../package.json` at runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN npm run build
 FROM node:24-slim AS production
 
 WORKDIR /app
-COPY --from=builder /app/build .
+COPY --from=builder /app/build ./build
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/package-lock.json ./package-lock.json
 
 EXPOSE 3000
-ENTRYPOINT [ "node", "index.js", "--http", "--port", "3000" ]
+ENTRYPOINT [ "node", "build/index.js", "--http", "--port", "3000" ]


### PR DESCRIPTION
The compiled entrypoint uses `require("../package.json")` from `build/index.js`, so production must keep `/app/build/index.js` with `/app/package.json` as its parent directory.

Previously the image copied `build/*` into `/app`, which broke resolution of `../package.json` at runtime (see https://github.com/baruchiro/paperless-mcp/issues/75).

- Copy `build` to `/app/build`
- Run `node build/index.js` with the existing `--http` / port flags

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker build configuration to ensure the production image correctly executes and resolves application dependencies at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->