### PR TITLE
fix: use valid URI scheme for document/thumbnail resources

### DIFF
--- a/.changeset/fix-resource-uri-validation.md
+++ b/.changeset/fix-resource-uri-validation.md
@@ -11,11 +11,13 @@ rejected these with `ValidationError: Input should be a valid URL,
 relative URL without a base`, making downloads and thumbnails
 unusable from any Python MCP client.
 
-Tools now return URIs under a custom `paperless://` scheme that is
-always well-formed regardless of filename content:
+Tools now return URIs under a custom `paperless://` scheme that mirrors
+the Paperless REST API paths, so the same identifiers can later back
+proper MCP resources (`resources/list` / `resources/read`):
 
-- `download_document` → `paperless://document/{id}/{encodeURIComponent(filename)}`
-- `get_document_thumbnail` → `paperless://thumbnail/{id}.webp`
+- `download_document` → `paperless://documents/{id}/download?filename=<encoded>`
+- `get_document_thumbnail` → `paperless://documents/{id}/thumb`
 
-The original filename is preserved (URL-encoded) inside the URI path,
-so clients that need the original name can still recover it.
+The original filename is preserved (URL-encoded) as a `filename` query
+parameter on the download URI, so clients that need the human-readable
+name can still recover it via standard URL parsing.

--- a/.changeset/fix-resource-uri-validation.md
+++ b/.changeset/fix-resource-uri-validation.md
@@ -1,0 +1,21 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix MCP resource URI validation for `download_document` and `get_document_thumbnail`.
+
+The two tools previously returned MCP resources whose `uri` was a raw
+filename (e.g. `"2026-02-15 Vendor Co._Mobile.pdf"`) or an unscoped
+string. Python MCP clients (the `mcp` package, pydantic-validated)
+rejected these with `ValidationError: Input should be a valid URL,
+relative URL without a base`, making downloads and thumbnails
+unusable from any Python MCP client.
+
+Tools now return URIs under a custom `paperless://` scheme that is
+always well-formed regardless of filename content:
+
+- `download_document` → `paperless://document/{id}/{encodeURIComponent(filename)}`
+- `get_document_thumbnail` → `paperless://thumbnail/{id}.webp`
+
+The original filename is preserved (URL-encoded) inside the URI path,
+so clients that need the original name can still recover it.

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -6,6 +6,10 @@ import { arrayNotEmpty, objectNotEmpty } from "./utils/empty";
 import { withErrorHandling } from "./utils/middlewares";
 import { validateCustomFields } from "./utils/monetary";
 import { CUSTOM_FIELD_VALUE_DESCRIPTION } from "./utils/descriptions";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "./utils/resourceUri";
 
 export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
   server.tool(
@@ -277,7 +281,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `paperless://document/${args.id}/${encodeURIComponent(filename)}`,
+              uri: buildDocumentResourceUri(args.id, filename),
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "application/pdf",
             },
@@ -301,7 +305,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `paperless://thumbnail/${args.id}.webp`,
+              uri: buildThumbnailResourceUri(args.id),
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "image/webp",
             },

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -277,7 +277,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: filename,
+              uri: `paperless://document/${args.id}/${encodeURIComponent(filename)}`,
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "application/pdf",
             },
@@ -301,7 +301,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `document-${args.id}-thumb.webp`,
+              uri: `paperless://thumbnail/${args.id}.webp`,
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "image/webp",
             },

--- a/src/tools/utils/resourceUri.test.ts
+++ b/src/tools/utils/resourceUri.test.ts
@@ -5,47 +5,56 @@ import {
   buildThumbnailResourceUri,
 } from "./resourceUri";
 
-test("buildDocumentResourceUri uses the paperless:// scheme", () => {
+test("buildDocumentResourceUri mirrors the REST download path", () => {
   const uri = buildDocumentResourceUri(1, "doc.pdf");
-  assert.match(uri, /^paperless:\/\/document\//);
+  assert.match(uri, /^paperless:\/\/documents\/1\/download(\?|$)/);
 });
 
-test("buildDocumentResourceUri encodes filenames with spaces", () => {
+test("buildDocumentResourceUri puts the filename in a query parameter", () => {
   const uri = buildDocumentResourceUri(1, "invoice 2026.pdf");
-  assert.equal(uri, "paperless://document/1/invoice%202026.pdf");
+  assert.equal(
+    uri,
+    "paperless://documents/1/download?filename=invoice%202026.pdf"
+  );
 });
 
-test("buildDocumentResourceUri encodes RFC-3986 reserved characters", () => {
+test("buildDocumentResourceUri encodes RFC-3986 reserved chars in the filename", () => {
   const uri = buildDocumentResourceUri(42, "weird ?#&=+name.pdf");
-  // encodeURIComponent encodes ?, #, &, =, +, and spaces — none of these
-  // should leak through and be mis-parsed as URI structure.
-  assert.doesNotMatch(uri, /[?#]/);
-  assert.match(uri, /^paperless:\/\/document\/42\//);
+  const url = new URL(uri);
+  // The path stays canonical — only the literal `?` that separates
+  // path from query is allowed; nothing from the filename should
+  // bleed into the path or break query parsing.
+  assert.equal(url.pathname, "/42/download");
+  assert.equal(url.searchParams.get("filename"), "weird ?#&=+name.pdf");
 });
 
 test("buildDocumentResourceUri encodes path separators inside filename", () => {
-  // If Paperless ever returned a filename containing a slash, it must
-  // not become an extra path segment.
+  // A filename containing a slash must not become an extra path segment.
   const uri = buildDocumentResourceUri(7, "sub/dir/file.pdf");
-  assert.equal(uri, "paperless://document/7/sub%2Fdir%2Ffile.pdf");
+  const url = new URL(uri);
+  assert.equal(url.pathname, "/7/download");
+  assert.equal(url.searchParams.get("filename"), "sub/dir/file.pdf");
 });
 
 test("buildDocumentResourceUri preserves unicode filenames", () => {
-  const uri = buildDocumentResourceUri(1, "Rechnüng — März.pdf");
-  // Roundtrip via decodeURIComponent should recover the original name.
-  const path = uri.replace("paperless://document/1/", "");
-  assert.equal(decodeURIComponent(path), "Rechnüng — März.pdf");
+  const original = "Rechnüng — März.pdf";
+  const uri = buildDocumentResourceUri(1, original);
+  // Roundtrip via URL parsing should recover the original name.
+  const url = new URL(uri);
+  assert.equal(url.searchParams.get("filename"), original);
 });
 
 test("buildDocumentResourceUri produces a valid URL", () => {
-  // Sanity: the constructed URI must parse via WHATWG URL.
   const uri = buildDocumentResourceUri(1, "Some File.pdf");
   assert.doesNotThrow(() => new URL(uri));
 });
 
-test("buildThumbnailResourceUri uses the paperless:// scheme with id and .webp", () => {
-  assert.equal(buildThumbnailResourceUri(1), "paperless://thumbnail/1.webp");
-  assert.equal(buildThumbnailResourceUri(123), "paperless://thumbnail/123.webp");
+test("buildThumbnailResourceUri mirrors the REST thumb path", () => {
+  assert.equal(buildThumbnailResourceUri(1), "paperless://documents/1/thumb");
+  assert.equal(
+    buildThumbnailResourceUri(123),
+    "paperless://documents/123/thumb"
+  );
 });
 
 test("buildThumbnailResourceUri produces a valid URL", () => {

--- a/src/tools/utils/resourceUri.test.ts
+++ b/src/tools/utils/resourceUri.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "./resourceUri";
+
+test("buildDocumentResourceUri uses the paperless:// scheme", () => {
+  const uri = buildDocumentResourceUri(1, "doc.pdf");
+  assert.match(uri, /^paperless:\/\/document\//);
+});
+
+test("buildDocumentResourceUri encodes filenames with spaces", () => {
+  const uri = buildDocumentResourceUri(1, "invoice 2026.pdf");
+  assert.equal(uri, "paperless://document/1/invoice%202026.pdf");
+});
+
+test("buildDocumentResourceUri encodes RFC-3986 reserved characters", () => {
+  const uri = buildDocumentResourceUri(42, "weird ?#&=+name.pdf");
+  // encodeURIComponent encodes ?, #, &, =, +, and spaces — none of these
+  // should leak through and be mis-parsed as URI structure.
+  assert.doesNotMatch(uri, /[?#]/);
+  assert.match(uri, /^paperless:\/\/document\/42\//);
+});
+
+test("buildDocumentResourceUri encodes path separators inside filename", () => {
+  // If Paperless ever returned a filename containing a slash, it must
+  // not become an extra path segment.
+  const uri = buildDocumentResourceUri(7, "sub/dir/file.pdf");
+  assert.equal(uri, "paperless://document/7/sub%2Fdir%2Ffile.pdf");
+});
+
+test("buildDocumentResourceUri preserves unicode filenames", () => {
+  const uri = buildDocumentResourceUri(1, "Rechnüng — März.pdf");
+  // Roundtrip via decodeURIComponent should recover the original name.
+  const path = uri.replace("paperless://document/1/", "");
+  assert.equal(decodeURIComponent(path), "Rechnüng — März.pdf");
+});
+
+test("buildDocumentResourceUri produces a valid URL", () => {
+  // Sanity: the constructed URI must parse via WHATWG URL.
+  const uri = buildDocumentResourceUri(1, "Some File.pdf");
+  assert.doesNotThrow(() => new URL(uri));
+});
+
+test("buildThumbnailResourceUri uses the paperless:// scheme with id and .webp", () => {
+  assert.equal(buildThumbnailResourceUri(1), "paperless://thumbnail/1.webp");
+  assert.equal(buildThumbnailResourceUri(123), "paperless://thumbnail/123.webp");
+});
+
+test("buildThumbnailResourceUri produces a valid URL", () => {
+  assert.doesNotThrow(() => new URL(buildThumbnailResourceUri(99)));
+});

--- a/src/tools/utils/resourceUri.ts
+++ b/src/tools/utils/resourceUri.ts
@@ -1,32 +1,33 @@
 /**
  * Resource URI builders for document/thumbnail downloads.
  *
- * MCP resource URIs are validated by Python MCP clients (pydantic) as
- * `AnyUrl` — they must be a valid URL or relative URL without a base.
- * Plain filenames or strings without a scheme fail this validation, so
- * we wrap them in a custom `paperless://` scheme that is always
- * well-formed regardless of filename content.
+ * URIs mirror the Paperless REST API paths under a custom `paperless://`
+ * scheme, so the same identifiers can later back proper MCP resources
+ * (`resources/list` / `resources/read`) without a second naming scheme.
+ *
+ * The scheme also keeps the URI well-formed regardless of filename
+ * content, which Python MCP clients (pydantic-validated) require.
  */
 
 /**
  * Builds a resource URI for a downloaded document.
  *
- * The original filename is preserved (URL-encoded) inside the URI path,
- * so clients that need the original name can still recover it.
+ * Mirrors `GET /api/documents/{id}/download/`. The original filename is
+ * preserved as a `filename` query parameter (URL-encoded) so clients
+ * that need the human-readable name can still recover it.
  */
 export function buildDocumentResourceUri(
   id: number,
   filename: string
 ): string {
-  return `paperless://document/${id}/${encodeURIComponent(filename)}`;
+  return `paperless://documents/${id}/download?filename=${encodeURIComponent(filename)}`;
 }
 
 /**
  * Builds a resource URI for a document thumbnail.
  *
- * Thumbnails have no meaningful filename, so we use a stable shape
- * derived from the document id alone.
+ * Mirrors `GET /api/documents/{id}/thumb/`.
  */
 export function buildThumbnailResourceUri(id: number): string {
-  return `paperless://thumbnail/${id}.webp`;
+  return `paperless://documents/${id}/thumb`;
 }

--- a/src/tools/utils/resourceUri.ts
+++ b/src/tools/utils/resourceUri.ts
@@ -1,0 +1,32 @@
+/**
+ * Resource URI builders for document/thumbnail downloads.
+ *
+ * MCP resource URIs are validated by Python MCP clients (pydantic) as
+ * `AnyUrl` — they must be a valid URL or relative URL without a base.
+ * Plain filenames or strings without a scheme fail this validation, so
+ * we wrap them in a custom `paperless://` scheme that is always
+ * well-formed regardless of filename content.
+ */
+
+/**
+ * Builds a resource URI for a downloaded document.
+ *
+ * The original filename is preserved (URL-encoded) inside the URI path,
+ * so clients that need the original name can still recover it.
+ */
+export function buildDocumentResourceUri(
+  id: number,
+  filename: string
+): string {
+  return `paperless://document/${id}/${encodeURIComponent(filename)}`;
+}
+
+/**
+ * Builds a resource URI for a document thumbnail.
+ *
+ * Thumbnails have no meaningful filename, so we use a stable shape
+ * derived from the document id alone.
+ */
+export function buildThumbnailResourceUri(id: number): string {
+  return `paperless://thumbnail/${id}.webp`;
+}


### PR DESCRIPTION
## Problem

`download_document` and `get_document_thumbnail` return MCP resources with the filename (or an arbitrary string) as the resource URI:

```js
// download_document
return {
  content: [{
    type: "resource",
    resource: {
      uri: filename, // e.g. "2026-02-15 Vendor Co._Mobile.pdf"
      blob: ...,
      mimeType: "application/pdf",
    },
  }],
};

// get_document_thumbnail
return {
  content: [{
    type: "resource",
    resource: {
      uri: `document-${args.id}-thumb.webp`,
      ...
    },
  }],
};
```

Python MCP clients (`mcp` package, pydantic-validated) reject these payloads because the URI is neither a valid URL nor a valid relative URL — anything with a space or many special characters fails `TextResourceContents.uri` / `BlobResourceContents.uri` validation:

```
ValidationError: 14 validation errors for CallToolResult
content.0.EmbeddedResource.resource.TextResourceContents.uri
  Input should be a valid URL, relative URL without a base
content.0.EmbeddedResource.resource.BlobResourceContents.uri
  Input should be a valid URL, relative URL without a base
```

The Paperless API call itself succeeds — only the MCP wrapper response fails validation, so downloads/thumbnails are unusable from any Python MCP client.

## Fix

Use a custom `paperless://` URI scheme so the URI is always well-formed regardless of filename content:

- `download_document` → `paperless://document/{id}/{encodeURIComponent(filename)}`
- `get_document_thumbnail` → `paperless://thumbnail/{id}.webp`

The original filename is preserved (URL-encoded) inside the `paperless://document/...` URI, so clients that want the original name can still recover it from the URI path. The mime type and blob are unchanged.

## Test plan

- [x] Verified upstream Paperless `/api/documents/{id}/download/` returns the file content correctly (not the issue).
- [x] Verified Python MCP / pydantic accepts `paperless://document/{id}/{encoded}` and `paperless://thumbnail/{id}.webp` as valid URIs.
- [x] Verified `download_document` succeeds end-to-end from a Python MCP client (was failing with ValidationError before).
- [x] No-op for non-validating clients — they receive the same shape with a different URI string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document download and thumbnail links to use stable, REST-like resource URIs so downloads and thumbnails validate and open correctly.
  * Filenames are preserved and URL-encoded in download links, preventing invalid/ambiguous addresses.
* **Tests**
  * Added tests to verify URI formats, encoding, and thumbnail paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baruchiro/paperless-mcp/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->