### PR TITLE
Fix bulk custom field parameters

### DIFF
--- a/.changeset/fix-bulk-custom-field-parameters.md
+++ b/.changeset/fix-bulk-custom-field-parameters.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix bulk document custom field edits to send Paperless-NGX compatible `add_custom_fields` parameters and preserve intentionally empty custom field values.

--- a/README.md
+++ b/README.md
@@ -215,9 +215,20 @@ bulk_edit_documents({
 bulk_edit_documents({
   documents: [12, 13],
   method: "modify_custom_fields",
-  add_custom_fields: {
-    "2": "שנה"
-  }
+  add_custom_fields: [
+    { field: 2, value: "שנה" }
+  ],
+  remove_custom_fields: []
+})
+
+// Set an empty custom field value, e.g. a date field used as a pending marker
+bulk_edit_documents({
+  documents: [14],
+  method: "modify_custom_fields",
+  add_custom_fields: [
+    { field: 9, value: "" }
+  ],
+  remove_custom_fields: []
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baruchiro/paperless-mcp",
-  "version": "0.4.1",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baruchiro/paperless-mcp",
-      "version": "0.4.1",
+      "version": "0.4.5",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.1",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -150,8 +150,7 @@ export interface BulkEditDocumentsResult {
 }
 
 export interface BulkEditParameters {
-  assign_custom_fields?: number[];
-  assign_custom_fields_values?: CustomFieldInstanceRequest[];
+  add_custom_fields?: Record<string, CustomFieldInstanceRequest["value"]>;
   remove_custom_fields?: number[];
   add_tags?: number[];
   remove_tags?: number[];

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -39,13 +39,7 @@ export interface CustomField {
   document_count: number;
 }
 
-export type CustomFieldValue =
-  | string
-  | number
-  | boolean
-  | number[]
-  | Record<string, unknown>
-  | null;
+export type CustomFieldValue = string | number | boolean | number[] | null;
 
 export interface CustomFieldInstance {
   field: number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -39,14 +39,22 @@ export interface CustomField {
   document_count: number;
 }
 
+export type CustomFieldValue =
+  | string
+  | number
+  | boolean
+  | number[]
+  | Record<string, unknown>
+  | null;
+
 export interface CustomFieldInstance {
   field: number;
-  value: string | number | boolean | object | null;
+  value: CustomFieldValue;
 }
 
 export interface CustomFieldInstanceRequest {
   field: number;
-  value: string | number | boolean | object | null;
+  value: CustomFieldValue;
 }
 
 export interface PaginationResponse<T> {

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -4,7 +4,7 @@ import { buildBulkEditParameters } from "./documents";
 
 test("buildBulkEditParameters sends Paperless bulk custom fields as id:value map", () => {
   const parameters = buildBulkEditParameters(
-    { remove_custom_fields: [] as number[] },
+    { remove_custom_fields: [] },
     [
       { field: 9, value: "" },
       { field: 10, value: "2026-05-14" },
@@ -32,12 +32,53 @@ test("buildBulkEditParameters preserves null custom field values", () => {
   });
 });
 
-
 test("buildBulkEditParameters includes Paperless-required empty custom field keys", () => {
   const parameters = buildBulkEditParameters({}, undefined, true);
 
   assert.deepEqual(parameters, {
     add_custom_fields: {},
     remove_custom_fields: [],
+  });
+});
+
+test("buildBulkEditParameters preserves an empty custom fields array", () => {
+  const parameters = buildBulkEditParameters({}, [], true);
+
+  assert.deepEqual(parameters, {
+    add_custom_fields: {},
+    remove_custom_fields: [],
+  });
+});
+
+test("buildBulkEditParameters combines base parameters with custom fields", () => {
+  const parameters = buildBulkEditParameters(
+    { add_tags: [3], remove_tags: [1, 2] },
+    [{ field: 9, value: "pending" }]
+  );
+
+  assert.deepEqual(parameters, {
+    add_tags: [3],
+    remove_tags: [1, 2],
+    add_custom_fields: {
+      "9": "pending",
+    },
+  });
+});
+
+test("buildBulkEditParameters preserves supported custom field value types", () => {
+  const parameters = buildBulkEditParameters({}, [
+    { field: 1, value: 42 },
+    { field: 2, value: true },
+    { field: 3, value: "" },
+    { field: 4, value: null },
+    { field: 5, value: [123, 456] },
+  ]);
+
+  assert.deepEqual(parameters.add_custom_fields, {
+    "1": 42,
+    "2": true,
+    "3": "",
+    "4": null,
+    "5": [123, 456],
   });
 });

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildBulkEditParameters } from "./documents";
+
+test("buildBulkEditParameters sends Paperless bulk custom fields as id:value map", () => {
+  const parameters = buildBulkEditParameters(
+    { remove_custom_fields: [] as number[] },
+    [
+      { field: 9, value: "" },
+      { field: 10, value: "2026-05-14" },
+    ]
+  );
+
+  assert.deepEqual(parameters, {
+    remove_custom_fields: [],
+    add_custom_fields: {
+      "9": "",
+      "10": "2026-05-14",
+    },
+  });
+  assert.ok(!("assign_custom_fields" in parameters));
+  assert.ok(!("assign_custom_fields_values" in parameters));
+});
+
+test("buildBulkEditParameters preserves null custom field values", () => {
+  const parameters = buildBulkEditParameters({}, [{ field: 9, value: null }]);
+
+  assert.deepEqual(parameters, {
+    add_custom_fields: {
+      "9": null,
+    },
+  });
+});
+
+
+test("buildBulkEditParameters includes Paperless-required empty custom field keys", () => {
+  const parameters = buildBulkEditParameters({}, undefined, true);
+
+  assert.deepEqual(parameters, {
+    add_custom_fields: {},
+    remove_custom_fields: [],
+  });
+});

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -42,6 +42,15 @@ test("buildBulkEditParameters includes Paperless-required empty custom field key
 });
 
 test("buildBulkEditParameters preserves an empty custom fields array", () => {
+  const parameters = buildBulkEditParameters({}, []);
+
+  assert.deepEqual(parameters, {
+    add_custom_fields: {},
+  });
+  assert.ok(!("remove_custom_fields" in parameters));
+});
+
+test("buildBulkEditParameters preserves an empty custom fields array with defaults", () => {
   const parameters = buildBulkEditParameters({}, [], true);
 
   assert.deepEqual(parameters, {

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -20,12 +20,27 @@ export type BulkCustomFieldParameters = {
 };
 
 /**
- * Builds Paperless-NGX bulk edit parameters.
+ * Builds Paperless-NGX bulk edit parameters from base parameters plus optional
+ * custom field updates.
  *
- * `modify_custom_fields` expects custom field updates as an `add_custom_fields`
- * record keyed by field id. When `includeCustomFieldDefaults` is true, empty
- * `add_custom_fields` and `remove_custom_fields` values are included because
- * Paperless validates that both keys exist for custom-field bulk edits.
+ * Paperless-NGX expects custom field bulk updates as an `add_custom_fields`
+ * record keyed by custom field id. `addCustomFields` is accepted as an array for
+ * the MCP tool schema and transformed into that id-to-value record while
+ * preserving supported value types, including `number[]` document links and
+ * `null` resets. Passing an empty `addCustomFields` array intentionally produces
+ * an empty `add_custom_fields` record.
+ *
+ * When `includeCustomFieldDefaults` is true, the function also initializes
+ * `add_custom_fields` and `remove_custom_fields` with empty defaults using
+ * nullish coalescing (`??=`). This keeps the `modify_custom_fields` method's
+ * payload shape acceptable to Paperless even when no field values are supplied.
+ *
+ * @param parameters - Base bulk edit parameters to include in the result.
+ * @param addCustomFields - Optional custom field updates to map by field id.
+ * @param includeCustomFieldDefaults - Whether to include empty custom field
+ * defaults required by `modify_custom_fields`.
+ * @returns The merged API parameters with custom field updates transformed into
+ * Paperless-NGX's `add_custom_fields` record shape.
  */
 export function buildBulkEditParameters<T extends Record<string, unknown>>(
   parameters: T,
@@ -36,7 +51,7 @@ export function buildBulkEditParameters<T extends Record<string, unknown>>(
     ...parameters,
   };
 
-  if (addCustomFields && addCustomFields.length > 0) {
+  if (addCustomFields) {
     apiParameters.add_custom_fields = Object.fromEntries(
       addCustomFields.map((customField) => [
         String(customField.field),

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -7,6 +7,44 @@ import { withErrorHandling } from "./utils/middlewares";
 import { validateCustomFields } from "./utils/monetary";
 import { CUSTOM_FIELD_VALUE_DESCRIPTION } from "./utils/descriptions";
 
+export type BulkCustomFieldValue = string | number | boolean | number[] | null;
+
+export type BulkCustomFieldUpdate = {
+  field: number;
+  value: BulkCustomFieldValue;
+};
+
+export type BulkCustomFieldParameters = {
+  add_custom_fields?: Record<string, BulkCustomFieldValue>;
+  remove_custom_fields?: number[];
+};
+
+export function buildBulkEditParameters<T extends Record<string, unknown>>(
+  parameters: T,
+  addCustomFields?: BulkCustomFieldUpdate[],
+  includeCustomFieldDefaults = false
+): T & BulkCustomFieldParameters {
+  const apiParameters: T & BulkCustomFieldParameters = {
+    ...parameters,
+  };
+
+  if (addCustomFields && addCustomFields.length > 0) {
+    apiParameters.add_custom_fields = Object.fromEntries(
+      addCustomFields.map((customField) => [
+        String(customField.field),
+        customField.value,
+      ])
+    );
+  }
+
+  if (includeCustomFieldDefaults) {
+    apiParameters.add_custom_fields ??= {};
+    apiParameters.remove_custom_fields ??= [];
+  }
+
+  return apiParameters;
+}
+
 export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
   server.tool(
     "bulk_edit_documents",
@@ -95,19 +133,14 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
       validateCustomFields(add_custom_fields);
 
-      // Transform add_custom_fields into the two separate API parameters
-      const apiParameters = { ...parameters };
-      if (add_custom_fields && add_custom_fields.length > 0) {
-        apiParameters.assign_custom_fields = add_custom_fields.map(
-          (cf) => cf.field
-        );
-        apiParameters.assign_custom_fields_values = add_custom_fields;
-      }
-
       const response = await api.bulkEditDocuments(
         documents,
         method,
-        apiParameters
+        buildBulkEditParameters(
+          parameters,
+          add_custom_fields,
+          method === "modify_custom_fields"
+        )
       );
       return {
         content: [

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -19,6 +19,14 @@ export type BulkCustomFieldParameters = {
   remove_custom_fields?: number[];
 };
 
+/**
+ * Builds Paperless-NGX bulk edit parameters.
+ *
+ * `modify_custom_fields` expects custom field updates as an `add_custom_fields`
+ * record keyed by field id. When `includeCustomFieldDefaults` is true, empty
+ * `add_custom_fields` and `remove_custom_fields` values are included because
+ * Paperless validates that both keys exist for custom-field bulk edits.
+ */
 export function buildBulkEditParameters<T extends Record<string, unknown>>(
   parameters: T,
   addCustomFields?: BulkCustomFieldUpdate[],


### PR DESCRIPTION
## Summary

- Send `modify_custom_fields` bulk edits using Paperless-NGX's expected `add_custom_fields` id/value map instead of unsupported `assign_custom_fields` fields.
- Include Paperless-required empty `add_custom_fields` / `remove_custom_fields` defaults for `modify_custom_fields` operations.
- Preserve empty string and `null` custom field values so workflows can create intentionally empty fields, e.g. pending markers on date custom fields.
- Update README examples and add unit tests for the parameter transformation.

## Why

Paperless-NGX validates bulk custom field edits with `parameters.add_custom_fields` and `parameters.remove_custom_fields`. The current MCP transformation sends `assign_custom_fields` and `assign_custom_fields_values`, which Paperless rejects with errors like `add_custom_fields not specified`.

This also prevents setting an intentionally empty custom field value used by workflows such as "date field is present but empty = pending".

## Tests

- `npm test`
- `npm run build`

Note: local environment is Node 22, while the package declares Node >=24, so npm prints an EBADENGINE warning during install. Tests and TypeScript build pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Bulk document custom-field edits now use a string-key → value mapping for added fields; previous bulk-field parameters removed.

* **Documentation**
  * Updated examples for bulk modify operations, including how to add/remove custom fields and how to set fields to empty values.

* **Tests**
  * Added coverage verifying bulk-edit parameter shape, preservation of empty/null values, and supported value types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baruchiro/paperless-mcp/pull/89)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->