### PR TITLE
fix: strip delete_originals from bulk_edit API call; make API version configurable

### DIFF
--- a/.changeset/fix-bulk-delete-api-version.md
+++ b/.changeset/fix-bulk-delete-api-version.md
@@ -1,0 +1,7 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix `bulk_edit_documents` delete: strip `delete_originals` from API parameters (it is an MCP-side guardrail and caused a 400 error when forwarded to Paperless).
+
+Fix HTTP 406 errors against Paperless-ngx v3.0.0+: the API version in the `Accept` header is now configurable via the `PAPERLESS_API_VERSION` environment variable (defaults to `"5"` for backwards compatibility with v2.x; set to `"10"` for v3.x).

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -31,7 +31,7 @@ export class PaperlessAPI {
 
     const mergedHeaders = {
       Authorization: `Token ${this.token}`,
-      Accept: "application/json; version=5",
+      Accept: `application/json; version=${process.env.PAPERLESS_API_VERSION || "5"}`,
       "Accept-Language": "en-US,en;q=0.9",
       ...(isJson ? { "Content-Type": "application/json" } : {}),
       ...headersToObject(options.headers),

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -91,7 +91,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           "Confirmation required for destructive operation. Set confirm: true to proceed."
         );
       }
-      const { documents, method, add_custom_fields, confirm, ...parameters } = args;
+      const { documents, method, add_custom_fields, confirm, delete_originals, ...parameters } = args;
 
       validateCustomFields(add_custom_fields);
 


### PR DESCRIPTION
## Summary

Fixes two bugs reported in issues #91 and #93.

### Fix 1: Strip `delete_originals` from bulk_edit parameters (closes #91)

`delete_originals` was being forwarded inside the `parameters` object to Paperless's bulk-edit endpoint, causing a 400 error on `delete` operations:

```
delete() got an unexpected keyword argument 'delete_originals'
```

This is the same pattern as the `confirm` fix in #69 — both are MCP-side guardrails that must be consumed by the wrapper, not sent over the wire. The fix destructures `delete_originals` out of `args` before building the API payload.

### Fix 2: Make API version configurable via `PAPERLESS_API_VERSION` env var (closes #93)

The `Accept` header version was hardcoded to `5`, which Paperless-ngx v3.0.0 no longer accepts (returns HTTP 406). Paperless v3.x requires `version=9` or `version=10`.

The version is now read from `PAPERLESS_API_VERSION`, defaulting to `"5"` for backwards compatibility with v2.x. Users on v3.x can set:

```
PAPERLESS_API_VERSION=10
```

## Test plan

- [ ] `bulk_edit_documents` with `method: "delete"` and `confirm: true` completes without 400 error
- [ ] `bulk_edit_documents` with `method: "delete"`, `confirm: true`, and `delete_originals: true` completes without 400 error
- [ ] Existing Paperless v2.x users: no change in behavior (default `version=5`)
- [ ] Paperless v3.x users: set `PAPERLESS_API_VERSION=10`, all tool calls succeed instead of returning 406

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1EUqWyys9guk7uf3dpuS)_