### PR TITLE
fix(api): read API version from env var, surface clear 406 error message

### DIFF
--- a/.changeset/api-version-env-var.md
+++ b/.changeset/api-version-env-var.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Add `PAPERLESS_API_VERSION` environment variable to configure the Paperless-ngx REST API version (default: `5`). Set to `10` for Paperless-ngx v3+. On HTTP 406, a clear error message is shown directing users to set this variable.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Add these to your MCP config file:
    - `your-api-token` with the token you just generated
    - `https://your-public-domain.com` with your public Paperless-NGX URL (optional, falls back to PAPERLESS_URL)
 
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PAPERLESS_URL` | Yes | — | Base URL of your Paperless-NGX instance |
+| `PAPERLESS_API_KEY` | Yes | — | API token from your Paperless-NGX profile |
+| `PAPERLESS_PUBLIC_URL` | No | `PAPERLESS_URL` | Public-facing URL for document links |
+| `PAPERLESS_API_VERSION` | No | `5` | Paperless-ngx REST API version. Use `10` for Paperless-ngx v3+. If you see HTTP 406 errors, set this to `10`. |
+
 That's it! Now you can ask Claude to help you manage your Paperless-NGX documents.
 
 ### Example Usage

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -17,12 +17,15 @@ import {
 import { headersToObject } from "./utils";
 
 export class PaperlessAPI {
+  private readonly apiVersion: string;
+
   constructor(
     private readonly baseUrl: string,
     private readonly token: string
   ) {
     this.baseUrl = baseUrl;
     this.token = token;
+    this.apiVersion = process.env.PAPERLESS_API_VERSION || "5";
   }
 
   async request<T = any>(path: string, options: RequestInit = {}) {
@@ -31,7 +34,7 @@ export class PaperlessAPI {
 
     const mergedHeaders = {
       Authorization: `Token ${this.token}`,
-      Accept: "application/json; version=5",
+      Accept: `application/json; version=${this.apiVersion}`,
       "Accept-Language": "en-US,en;q=0.9",
       ...(isJson ? { "Content-Type": "application/json" } : {}),
       ...headersToObject(options.headers),
@@ -64,13 +67,19 @@ export class PaperlessAPI {
 
       return body;
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 406) {
+        throw new Error(
+          `HTTP 406: Paperless-ngx rejected API version ${this.apiVersion}. ` +
+            `Set the PAPERLESS_API_VERSION environment variable to match your server's API version (e.g., "10" for Paperless-ngx v3+).`
+        );
+      }
       console.error({
         error: "Error executing request",
         message: error instanceof Error ? error.message : String(error),
         url,
         options,
-        responseData: (error as any)?.response?.data,
-        status: (error as any)?.response?.status,
+        responseData: axios.isAxiosError(error) ? error.response?.data : undefined,
+        status: axios.isAxiosError(error) ? error.response?.status : undefined,
       });
       throw error;
     }
@@ -126,22 +135,33 @@ export class PaperlessAPI {
       );
     }
 
-    const response = await axios.post<string>(
-      `${this.baseUrl}/api/documents/post_document/`,
-      formData,
-      {
-        headers: {
-          Authorization: `Token ${this.token}`,
-          ...formData.getHeaders(),
-        },
+    try {
+      const response = await axios.post<string>(
+        `${this.baseUrl}/api/documents/post_document/`,
+        formData,
+        {
+          headers: {
+            Authorization: `Token ${this.token}`,
+            Accept: `application/json; version=${this.apiVersion}`,
+            ...formData.getHeaders(),
+          },
+        }
+      );
+
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(`HTTP error! status: ${response.status}`);
       }
-    );
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 406) {
+        throw new Error(
+          `HTTP 406: Paperless-ngx rejected API version ${this.apiVersion}. ` +
+            `Set the PAPERLESS_API_VERSION environment variable to match your server's API version (e.g., "10" for Paperless-ngx v3+).`
+        );
+      }
+      throw error;
     }
-
-    return response.data;
   }
 
   async getDocuments(query = ""): Promise<DocumentsResponse> {


### PR DESCRIPTION
Replace the per-request version flip/retry with a single immutable
apiVersion read from PAPERLESS_API_VERSION at construction time (default "5").
On HTTP 406, throw an actionable error message directing users to set the
env var. Document the variable in README.

https://claude.ai/code/session_01RRup9j9FWH1QRjwG32P8FV

Fixes #93