### PR TITLE
Add GitHub Actions workflow to automatically manage stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          ascending: true
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-message: >
+            Issue has been marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions.
+          stale-pr-message: >
+            Pull request has been marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions.
+          close-issue-reason: not_planned
+          exempt-issue-labels: not-stale
+          exempt-pr-labels: not-stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ascending: true
           days-before-stale: 60
-          days-before-close: 14
+          days-before-close: 30
           stale-issue-message: >
             Issue has been marked as stale because it has not had recent activity.
             It will be closed if no further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically marks and closes stale issues and pull requests to help keep the repository clean and organized.

## Key Changes
- Added `.github/workflows/stale.yml` workflow file that:
  - Runs daily at 1:30 AM UTC via scheduled cron job
  - Can also be triggered manually via `workflow_dispatch`
  - Marks issues as stale after 60 days of inactivity
  - Marks pull requests as stale after 60 days of inactivity
  - Automatically closes stale items after an additional 30 days without activity
  - Provides customized messages for both stale issues and pull requests
  - Allows exempting items from stale automation using `not-stale` labels on both issues and PRs
  - Closes issues with "not_planned" reason

## Implementation Details
- Uses the official `actions/stale@v9` action
- Processes items in ascending order (oldest first)
- Includes helpful messages to thank contributors and explain the stale policy
- Provides escape hatch via `not-stale` label for items that should remain open despite inactivity

https://claude.ai/code/session_018q3LCVHiCwEnMxywCd6ZMq