### PR TITLE
Replace Hebrew text with English in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ bulk_edit_documents({
   documents: [12, 13],
   method: "modify_custom_fields",
   add_custom_fields: [
-    { field: 2, value: "שנה" }
+    { field: 2, value: "year" }
   ],
   remove_custom_fields: []
 })


### PR DESCRIPTION
## Summary

- Replaced the Hebrew word `שנה` ("year") with its English equivalent `"year"` in the `bulk_edit_documents` code example in README.md

## Test plan

- [ ] Verify the README example is readable and consistent with the rest of the documentation

https://claude.ai/code/session_011LGXjipifd2owhUZD1PWW6

---
_Generated by [Claude Code](https://claude.ai/code/session_011LGXjipifd2owhUZD1PWW6)_