### PR TITLE
fix: strip MCP-only params from bulk_edit delete request to Paperless

### DIFF
--- a/.changeset/fix-bulk-delete-parameters.md
+++ b/.changeset/fix-bulk-delete-parameters.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix `bulk_edit_documents` with `method: "delete"` failing with HTTP 400 — MCP-only parameters (`confirm`, `delete_originals`) are no longer forwarded to the Paperless bulk-edit endpoint, which doesn't accept extra kwargs for the `delete` action.

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -159,11 +159,13 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       const response = await api.bulkEditDocuments(
         documents,
         method,
-        buildBulkEditParameters(
-          parameters,
-          add_custom_fields,
-          method === "modify_custom_fields"
-        )
+        method === "delete"
+          ? {}
+          : buildBulkEditParameters(
+              parameters,
+              add_custom_fields,
+              method === "modify_custom_fields"
+            )
       );
       return {
         content: [


### PR DESCRIPTION
Closes #91

## Summary

- When `method: "delete"`, Paperless's `delete()` action accepts no extra kwargs. The MCP wrapper was forwarding `confirm` (and potentially `delete_originals`) in the `parameters` object, causing a `400 Bad Request` from Paperless.
- `confirm` is an MCP-side safety guardrail and was already being stripped by destructuring on the handler line; however `delete_originals` was still included in the spread `...parameters`.
- Fix: for the `delete` method, pass an empty `parameters: {}` object to the Paperless API instead of the user-supplied parameter spread.

## Test plan

- [ ] Run existing test suite — all 10 tests pass
- [ ] Manually call `bulk_edit_documents` with `method: "delete"` and `confirm: true` — should succeed (no `parameters` forwarded)
- [ ] Call with `method: "delete"`, `confirm: true`, and `delete_originals: true` — should no longer 400
- [ ] Call with a non-delete method (e.g. `add_tag`) — parameters still forwarded correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_018wRYWcNE4fmxKQ4qrSHaFX)_