### PR TITLE
feat: add MCP resources support for documents (closes #90)

### DIFF
--- a/.changeset/add-mcp-document-resources.md
+++ b/.changeset/add-mcp-document-resources.md
@@ -1,0 +1,25 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+Add MCP `resources/list` and `resources/read` support for documents (issue #90).
+
+Each Paperless document is now exposed as two MCP resources under the
+`paperless://` scheme established by the resource-URI fix:
+
+- `paperless://documents/{id}/download` — the document file
+- `paperless://documents/{id}/thumb` — the document thumbnail
+
+Clients that understand MCP resources can list them via `resources/list`
+and lazy-fetch content via `resources/read`. This keeps large binary
+payloads out of tool results — important for clients (e.g. n8n LangChain
+agents) that accumulate full tool results in the conversation context.
+
+The `download_document` and `get_document_thumbnail` tools now return a
+resource reference (URI + mime type) instead of an inline base64 blob.
+To fetch the actual bytes, call `resources/read` with the URI. The
+`download_document` URI also supports an `?original=true` flag.
+
+The resource `name` field carries the human-readable filename, so
+filename info that previously had to be encoded in the URI is now
+available via resource metadata.

--- a/.changeset/fix-resource-uri-validation.md
+++ b/.changeset/fix-resource-uri-validation.md
@@ -15,9 +15,9 @@ Tools now return URIs under a custom `paperless://` scheme that mirrors
 the Paperless REST API paths, so the same identifiers can later back
 proper MCP resources (`resources/list` / `resources/read`):
 
-- `download_document` → `paperless://documents/{id}/download?filename=<encoded>`
+- `download_document` → `paperless://documents/{id}/download`
 - `get_document_thumbnail` → `paperless://documents/{id}/thumb`
 
-The original filename is preserved (URL-encoded) as a `filename` query
-parameter on the download URI, so clients that need the human-readable
-name can still recover it via standard URL parsing.
+URIs are intentionally canonical and filename-free; the human-readable
+filename is surfaced via resource metadata (the `name` field on each
+`Resource`) rather than embedded in the URI.

--- a/.changeset/fix-resource-uri-validation.md
+++ b/.changeset/fix-resource-uri-validation.md
@@ -11,11 +11,13 @@ rejected these with `ValidationError: Input should be a valid URL,
 relative URL without a base`, making downloads and thumbnails
 unusable from any Python MCP client.
 
-Tools now return URIs under a custom `paperless://` scheme that is
-always well-formed regardless of filename content:
+Tools now return URIs under a custom `paperless://` scheme that mirrors
+the Paperless REST API paths, so the same identifiers can later back
+proper MCP resources (`resources/list` / `resources/read`):
 
-- `download_document` → `paperless://document/{id}/{encodeURIComponent(filename)}`
-- `get_document_thumbnail` → `paperless://thumbnail/{id}.webp`
+- `download_document` → `paperless://documents/{id}/download?filename=<encoded>`
+- `get_document_thumbnail` → `paperless://documents/{id}/thumb`
 
-The original filename is preserved (URL-encoded) inside the URI path,
-so clients that need the original name can still recover it.
+The original filename is preserved (URL-encoded) as a `filename` query
+parameter on the download URI, so clients that need the human-readable
+name can still recover it via standard URL parsing.

--- a/.changeset/fix-resource-uri-validation.md
+++ b/.changeset/fix-resource-uri-validation.md
@@ -1,0 +1,21 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix MCP resource URI validation for `download_document` and `get_document_thumbnail`.
+
+The two tools previously returned MCP resources whose `uri` was a raw
+filename (e.g. `"2026-02-15 Vendor Co._Mobile.pdf"`) or an unscoped
+string. Python MCP clients (the `mcp` package, pydantic-validated)
+rejected these with `ValidationError: Input should be a valid URL,
+relative URL without a base`, making downloads and thumbnails
+unusable from any Python MCP client.
+
+Tools now return URIs under a custom `paperless://` scheme that is
+always well-formed regardless of filename content:
+
+- `download_document` → `paperless://document/{id}/{encodeURIComponent(filename)}`
+- `get_document_thumbnail` → `paperless://thumbnail/{id}.webp`
+
+The original filename is preserved (URL-encoded) inside the URI path,
+so clients that need the original name can still recover it.

--- a/src/resources/documents.test.ts
+++ b/src/resources/documents.test.ts
@@ -80,7 +80,11 @@ async function withResourceClient(
   }
 }
 
-test("resources/list exposes download and thumbnail resources for known documents", async () => {
+test("resources/list exposes download and thumbnail resources for the first page only", async () => {
+  // `all` lists IDs across every page (potentially tens of thousands of
+  // documents) — `resources/list` must not expand that or it will produce
+  // an unbounded payload. Only the documents on the fetched page should
+  // appear; the rest are still reachable via the resource template.
   const api = {
     getDocuments: async () =>
       emptyPaginationResponse(
@@ -110,13 +114,18 @@ test("resources/list exposes download and thumbnail resources for known document
         "paperless://documents/1/thumb",
         "paperless://documents/2/download",
         "paperless://documents/2/thumb",
-        "paperless://documents/3/download",
-        "paperless://documents/3/thumb",
       ]
     );
     assert.equal(result.resources[0].name, "Invoice download");
     assert.equal(result.resources[0].mimeType, "application/pdf");
-    assert.equal(result.resources[5].name, "Document 3 thumbnail");
+    assert.equal(result.resources[3].name, "Receipt thumbnail");
+    // Document 3 lives in `all` but not on this page — it must not leak in.
+    for (const resource of result.resources) {
+      assert.ok(
+        !resource.uri.includes("/3/"),
+        `unexpected page-3 resource in list: ${resource.uri}`
+      );
+    }
   });
 });
 

--- a/src/resources/documents.test.ts
+++ b/src/resources/documents.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types";
+import type { AxiosResponse } from "axios";
+import { PaperlessAPI } from "../api/PaperlessAPI";
+import { createDocument } from "../test/mocks/paperlessApi";
+import { registerDocumentResources } from "./documents";
+
+class TestTransport implements Transport {
+  peer?: TestTransport;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  async start(): Promise<void> {}
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    queueMicrotask(() => this.peer?.onmessage?.(message));
+  }
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+}
+
+function createTransportPair() {
+  const clientTransport = new TestTransport();
+  const serverTransport = new TestTransport();
+  clientTransport.peer = serverTransport;
+  serverTransport.peer = clientTransport;
+  return { clientTransport, serverTransport };
+}
+
+function emptyPaginationResponse<T>(results: T[] = [], all: number[] = []) {
+  return {
+    count: results.length,
+    next: null,
+    previous: null,
+    all,
+    results,
+  };
+}
+
+function createBinaryResponse(
+  body: string,
+  contentType: string
+): AxiosResponse<ArrayBuffer> {
+  return {
+    data: Buffer.from(body),
+    status: 200,
+    statusText: "OK",
+    headers: {
+      "content-type": contentType,
+    },
+    config: {},
+  } as unknown as AxiosResponse<ArrayBuffer>;
+}
+
+async function withResourceClient(
+  api: PaperlessAPI,
+  run: (client: Client) => Promise<void>
+) {
+  const server = new McpServer({ name: "paperless-test", version: "1.0.0" });
+  registerDocumentResources(server, api);
+
+  const client = new Client({ name: "paperless-test-client", version: "1.0.0" });
+  const { clientTransport, serverTransport } = createTransportPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    await run(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+test("resources/list exposes download and thumbnail resources for known documents", async () => {
+  const api = {
+    getDocuments: async () =>
+      emptyPaginationResponse(
+        [
+          createDocument({
+            id: 1,
+            title: "Invoice",
+            mime_type: "application/pdf",
+          }),
+          createDocument({
+            id: 2,
+            title: "Receipt",
+            mime_type: "image/png",
+          }),
+        ],
+        [1, 2, 3]
+      ),
+  } as unknown as PaperlessAPI;
+
+  await withResourceClient(api, async (client) => {
+    const result = await client.listResources();
+
+    assert.deepEqual(
+      result.resources.map((resource) => resource.uri),
+      [
+        "paperless://documents/1/download",
+        "paperless://documents/1/thumb",
+        "paperless://documents/2/download",
+        "paperless://documents/2/thumb",
+        "paperless://documents/3/download",
+        "paperless://documents/3/thumb",
+      ]
+    );
+    assert.equal(result.resources[0].name, "Invoice download");
+    assert.equal(result.resources[0].mimeType, "application/pdf");
+    assert.equal(result.resources[5].name, "Document 3 thumbnail");
+  });
+});
+
+test("resources/read fetches document downloads as lazy binary resources", async () => {
+  const calls: Array<{ id: number; original: boolean }> = [];
+  const api = {
+    getDocuments: async () => emptyPaginationResponse(),
+    downloadDocument: async (id: number, original: boolean) => {
+      calls.push({ id, original });
+      return createBinaryResponse("%PDF test", "application/pdf");
+    },
+  } as unknown as PaperlessAPI;
+
+  await withResourceClient(api, async (client) => {
+    const result = await client.readResource({
+      uri: "paperless://documents/2/download",
+    });
+
+    assert.deepEqual(calls, [{ id: 2, original: false }]);
+    assert.deepEqual(result.contents, [
+      {
+        uri: "paperless://documents/2/download",
+        mimeType: "application/pdf",
+        blob: Buffer.from("%PDF test").toString("base64"),
+      },
+    ]);
+  });
+});
+
+test("resources/read preserves original download query intent", async () => {
+  const calls: Array<{ id: number; original: boolean }> = [];
+  const api = {
+    getDocuments: async () => emptyPaginationResponse(),
+    downloadDocument: async (id: number, original: boolean) => {
+      calls.push({ id, original });
+      return createBinaryResponse("original file", "application/octet-stream");
+    },
+  } as unknown as PaperlessAPI;
+
+  await withResourceClient(api, async (client) => {
+    await client.readResource({
+      uri: "paperless://documents/7/download?original=true",
+    });
+
+    assert.deepEqual(calls, [{ id: 7, original: true }]);
+  });
+});
+
+test("resources/read fetches document thumbnails as lazy binary resources", async () => {
+  const calls: number[] = [];
+  const api = {
+    getDocuments: async () => emptyPaginationResponse(),
+    getThumbnail: async (id: number) => {
+      calls.push(id);
+      return createBinaryResponse("webp image", "image/webp");
+    },
+  } as unknown as PaperlessAPI;
+
+  await withResourceClient(api, async (client) => {
+    const result = await client.readResource({
+      uri: "paperless://documents/3/thumb",
+    });
+
+    assert.deepEqual(calls, [3]);
+    assert.deepEqual(result.contents, [
+      {
+        uri: "paperless://documents/3/thumb",
+        mimeType: "image/webp",
+        blob: Buffer.from("webp image").toString("base64"),
+      },
+    ]);
+  });
+});
+
+test("resources/read returns text contents for text responses", async () => {
+  const api = {
+    getDocuments: async () => emptyPaginationResponse(),
+    downloadDocument: async () =>
+      createBinaryResponse("plain text", "text/plain; charset=utf-8"),
+  } as unknown as PaperlessAPI;
+
+  await withResourceClient(api, async (client) => {
+    const result = await client.readResource({
+      uri: "paperless://documents/4/download",
+    });
+
+    assert.deepEqual(result.contents, [
+      {
+        uri: "paperless://documents/4/download",
+        mimeType: "text/plain; charset=utf-8",
+        text: "plain text",
+      },
+    ]);
+  });
+});

--- a/src/resources/documents.ts
+++ b/src/resources/documents.ts
@@ -46,19 +46,19 @@ export function registerDocumentResources(server: McpServer, api: PaperlessAPI) 
 export async function listDocumentResources(
   api: PaperlessAPI
 ): Promise<ListResourcesResult> {
+  // Return only the first page of documents. Paperless libraries can
+  // contain tens of thousands of documents; expanding the full `all`
+  // ID array would produce an unbounded `resources/list` payload.
+  // Clients that need to enumerate more documents can use the
+  // `list_documents` tool (which paginates) and read
+  // `paperless://documents/{id}/download` directly — the resource
+  // template handles `resources/read` for any document ID.
   const documentsResponse = await api.getDocuments();
   const documents = documentsResponse.results || [];
-  const documentsById = new Map<number, Document>(
-    documents.map((document) => [document.id, document])
-  );
-  const documentIds = (documentsResponse.all?.length
-    ? documentsResponse.all
-    : documents.map((document) => document.id)
-  ).filter((id): id is number => typeof id === "number");
 
   return {
-    resources: documentIds.flatMap((id) =>
-      buildResourcesForDocument(id, documentsById.get(id))
+    resources: documents.flatMap((document) =>
+      buildResourcesForDocument(document.id, document)
     ),
   };
 }

--- a/src/resources/documents.ts
+++ b/src/resources/documents.ts
@@ -1,0 +1,218 @@
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type {
+  BlobResourceContents,
+  ListResourcesResult,
+  ReadResourceResult,
+  Resource,
+  TextResourceContents,
+} from "@modelcontextprotocol/sdk/types";
+import type { AxiosResponse } from "axios";
+import { PaperlessAPI } from "../api/PaperlessAPI";
+import { Document } from "../api/types";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "../tools/utils/resourceUri";
+
+type TemplateVariables = Record<string, string | string[]>;
+
+export function registerDocumentResources(server: McpServer, api: PaperlessAPI) {
+  server.resource(
+    "paperless-document-resource",
+    new ResourceTemplate("paperless://documents/{id}/{resource}", {
+      list: async () => listDocumentResources(api),
+    }),
+    async (uri, variables) => readDocumentResource(api, uri, variables)
+  );
+
+  server.resource(
+    "paperless-document-original-download",
+    new ResourceTemplate("paperless://documents/{id}/download{?original}", {
+      list: undefined,
+    }),
+    async (uri, variables) =>
+      readDocumentDownloadResource(
+        api,
+        uri,
+        parseDocumentId(readVariable(variables, "id")),
+        isTrueQueryValue(readVariable(variables, "original"))
+      )
+  );
+}
+
+export async function listDocumentResources(
+  api: PaperlessAPI
+): Promise<ListResourcesResult> {
+  const documentsResponse = await api.getDocuments();
+  const documents = documentsResponse.results || [];
+  const documentsById = new Map<number, Document>(
+    documents.map((document) => [document.id, document])
+  );
+  const documentIds = (documentsResponse.all?.length
+    ? documentsResponse.all
+    : documents.map((document) => document.id)
+  ).filter((id): id is number => typeof id === "number");
+
+  return {
+    resources: documentIds.flatMap((id) =>
+      buildResourcesForDocument(id, documentsById.get(id))
+    ),
+  };
+}
+
+export async function readDocumentResource(
+  api: PaperlessAPI,
+  uri: URL,
+  variables: TemplateVariables
+): Promise<ReadResourceResult> {
+  assertPaperlessDocumentsUri(uri);
+
+  const id = parseDocumentId(readVariable(variables, "id"));
+  const resource = readVariable(variables, "resource").split("?")[0];
+
+  switch (resource) {
+    case "download":
+      return readDocumentDownloadResource(
+        api,
+        uri,
+        id,
+        isTrueQueryValue(uri.searchParams.get("original") || undefined)
+      );
+    case "thumbnail":
+    case "thumb":
+      return readDocumentThumbnailResource(api, uri, id);
+    default:
+      throw new Error(`Unsupported Paperless document resource: ${resource}`);
+  }
+}
+
+async function readDocumentDownloadResource(
+  api: PaperlessAPI,
+  uri: URL,
+  id: number,
+  original: boolean
+): Promise<ReadResourceResult> {
+  const response = await api.downloadDocument(id, original);
+  return {
+    contents: [
+      responseToResourceContents(uri.href, response, "application/octet-stream"),
+    ],
+  };
+}
+
+async function readDocumentThumbnailResource(
+  api: PaperlessAPI,
+  uri: URL,
+  id: number
+): Promise<ReadResourceResult> {
+  const response = await api.getThumbnail(id);
+  return {
+    contents: [responseToResourceContents(uri.href, response, "image/webp")],
+  };
+}
+
+function buildResourcesForDocument(id: number, document?: Document): Resource[] {
+  const label =
+    document?.title || document?.original_file_name || `Document ${id}`;
+
+  return [
+    {
+      uri: buildDocumentResourceUri(id),
+      name: `${label} download`,
+      description: `Full file content for Paperless document ${id}`,
+      mimeType: document?.mime_type || "application/octet-stream",
+    },
+    {
+      uri: buildThumbnailResourceUri(id),
+      name: `${label} thumbnail`,
+      description: `Thumbnail image for Paperless document ${id}`,
+      mimeType: "image/webp",
+    },
+  ];
+}
+
+function responseToResourceContents(
+  uri: string,
+  response: AxiosResponse<ArrayBuffer>,
+  fallbackMimeType: string
+): TextResourceContents | BlobResourceContents {
+  const mimeType = getHeader(response, "content-type") || fallbackMimeType;
+  const data = Buffer.from(response.data);
+
+  if (isTextMimeType(mimeType)) {
+    return {
+      uri,
+      mimeType,
+      text: data.toString("utf8"),
+    };
+  }
+
+  return {
+    uri,
+    mimeType,
+    blob: data.toString("base64"),
+  };
+}
+
+function assertPaperlessDocumentsUri(uri: URL): void {
+  if (uri.protocol !== "paperless:" || uri.hostname !== "documents") {
+    throw new Error(`Unsupported Paperless resource URI: ${uri.href}`);
+  }
+}
+
+function parseDocumentId(idValue: string): number {
+  const id = Number(idValue);
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error(`Invalid Paperless document id in resource URI: ${idValue}`);
+  }
+  return id;
+}
+
+function readVariable(variables: TemplateVariables, name: string): string {
+  const value = variables[name];
+  const stringValue = Array.isArray(value) ? value[0] : value;
+  if (!stringValue) {
+    throw new Error(`Missing ${name} in Paperless resource URI`);
+  }
+  return stringValue;
+}
+
+function isTrueQueryValue(value?: string): boolean {
+  return value === "true" || value === "1";
+}
+
+function getHeader(
+  response: AxiosResponse<ArrayBuffer>,
+  headerName: string
+): string | undefined {
+  const headers = response.headers as Record<string, unknown> & {
+    get?: (name: string) => unknown;
+  };
+
+  if (typeof headers.get === "function") {
+    const value = headers.get(headerName);
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  const value = headers[headerName] || headers[headerName.toLowerCase()];
+  if (Array.isArray(value)) {
+    return String(value[0]);
+  }
+  return typeof value === "string" ? value : undefined;
+}
+
+function isTextMimeType(mimeType: string): boolean {
+  const normalizedMimeType = mimeType.split(";")[0].trim().toLowerCase();
+  return (
+    normalizedMimeType.startsWith("text/") ||
+    normalizedMimeType === "application/json" ||
+    normalizedMimeType === "application/xml" ||
+    normalizedMimeType.endsWith("+json") ||
+    normalizedMimeType.endsWith("+xml")
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type express from "express";
 import { PaperlessAPI } from "./api/PaperlessAPI";
+import { registerDocumentResources } from "./resources/documents";
 import { registerCorrespondentTools } from "./tools/correspondents";
 import { registerCustomFieldTools } from "./tools/customFields";
 import { registerDocumentTools } from "./tools/documents";
@@ -26,6 +27,7 @@ export function createMcpServer({
     { instructions: buildInstructions(publicUrl) }
   );
   registerDocumentTools(server, api);
+  registerDocumentResources(server, api);
   registerTagTools(server, api);
   registerCorrespondentTools(server, api);
   registerDocumentTypeTools(server, api);

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -321,7 +321,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     "download_document",
     "Download a document file by ID. Returns a paperless:// resource URI; read the resource to fetch the file content.",
     {
-      id: z.number(),
+      id: z.number().int().positive(),
       original: z.boolean().optional(),
     },
     withErrorHandling(async (args, extra) => {
@@ -351,7 +351,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     "get_document_thumbnail",
     "Get a document thumbnail (image preview) by ID. Returns a paperless:// resource URI; read the resource to fetch the image content.",
     {
-      id: z.number(),
+      id: z.number().int().positive(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -6,6 +6,10 @@ import { arrayNotEmpty, objectNotEmpty } from "./utils/empty";
 import { withErrorHandling } from "./utils/middlewares";
 import { validateCustomFields } from "./utils/monetary";
 import { CUSTOM_FIELD_VALUE_DESCRIPTION } from "./utils/descriptions";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "./utils/resourceUri";
 
 export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
   server.tool(
@@ -277,7 +281,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `paperless://document/${args.id}/${encodeURIComponent(filename)}`,
+              uri: buildDocumentResourceUri(args.id, filename),
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "application/pdf",
             },
@@ -301,7 +305,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `paperless://thumbnail/${args.id}.webp`,
+              uri: buildThumbnailResourceUri(args.id),
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "image/webp",
             },

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -319,29 +319,27 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
   server.tool(
     "download_document",
-    "Download a document file by ID. Returns the document as a base64-encoded resource.",
+    "Download a document file by ID. Returns a paperless:// resource URI; read the resource to fetch the file content.",
     {
       id: z.number(),
       original: z.boolean().optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      const response = await api.downloadDocument(args.id, args.original);
-      const filename =
-        (typeof response.headers.get === "function"
-          ? response.headers.get("content-disposition")
-          : response.headers["content-disposition"]
-        )
-          ?.split("filename=")[1]
-          ?.replace(/"/g, "") || `document-${args.id}`;
+      const uri = buildDocumentResourceUri(args.id, {
+        original: args.original,
+      });
       return {
         content: [
           {
             type: "resource",
             resource: {
-              uri: buildDocumentResourceUri(args.id, filename),
-              blob: Buffer.from(response.data).toString("base64"),
-              mimeType: "application/pdf",
+              uri,
+              // MCP SDK 1.11 embedded resources require text or blob. Keep the
+              // existing resource-shaped tool result while making resources/read
+              // the canonical place for the large binary payload.
+              text: "",
+              mimeType: "application/octet-stream",
             },
           },
         ],
@@ -351,20 +349,21 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
   server.tool(
     "get_document_thumbnail",
-    "Get a document thumbnail (image preview) by ID. Returns the thumbnail as a base64-encoded WebP image resource.",
+    "Get a document thumbnail (image preview) by ID. Returns a paperless:// resource URI; read the resource to fetch the image content.",
     {
       id: z.number(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      const response = await api.getThumbnail(args.id);
       return {
         content: [
           {
             type: "resource",
             resource: {
               uri: buildThumbnailResourceUri(args.id),
-              blob: Buffer.from(response.data).toString("base64"),
+              // See download_document above: the binary thumbnail is fetched
+              // lazily through resources/read instead of embedded here.
+              text: "",
               mimeType: "image/webp",
             },
           },

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -277,7 +277,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: filename,
+              uri: `paperless://document/${args.id}/${encodeURIComponent(filename)}`,
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "application/pdf",
             },
@@ -301,7 +301,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           {
             type: "resource",
             resource: {
-              uri: `document-${args.id}-thumb.webp`,
+              uri: `paperless://thumbnail/${args.id}.webp`,
               blob: Buffer.from(response.data).toString("base64"),
               mimeType: "image/webp",
             },

--- a/src/tools/utils/resourceUri.test.ts
+++ b/src/tools/utils/resourceUri.test.ts
@@ -5,47 +5,56 @@ import {
   buildThumbnailResourceUri,
 } from "./resourceUri";
 
-test("buildDocumentResourceUri uses the paperless:// scheme", () => {
+test("buildDocumentResourceUri mirrors the REST download path", () => {
   const uri = buildDocumentResourceUri(1, "doc.pdf");
-  assert.match(uri, /^paperless:\/\/document\//);
+  assert.match(uri, /^paperless:\/\/documents\/1\/download(\?|$)/);
 });
 
-test("buildDocumentResourceUri encodes filenames with spaces", () => {
+test("buildDocumentResourceUri puts the filename in a query parameter", () => {
   const uri = buildDocumentResourceUri(1, "invoice 2026.pdf");
-  assert.equal(uri, "paperless://document/1/invoice%202026.pdf");
+  assert.equal(
+    uri,
+    "paperless://documents/1/download?filename=invoice%202026.pdf"
+  );
 });
 
-test("buildDocumentResourceUri encodes RFC-3986 reserved characters", () => {
+test("buildDocumentResourceUri encodes RFC-3986 reserved chars in the filename", () => {
   const uri = buildDocumentResourceUri(42, "weird ?#&=+name.pdf");
-  // encodeURIComponent encodes ?, #, &, =, +, and spaces — none of these
-  // should leak through and be mis-parsed as URI structure.
-  assert.doesNotMatch(uri, /[?#]/);
-  assert.match(uri, /^paperless:\/\/document\/42\//);
+  const url = new URL(uri);
+  // The path stays canonical — only the literal `?` that separates
+  // path from query is allowed; nothing from the filename should
+  // bleed into the path or break query parsing.
+  assert.equal(url.pathname, "/42/download");
+  assert.equal(url.searchParams.get("filename"), "weird ?#&=+name.pdf");
 });
 
 test("buildDocumentResourceUri encodes path separators inside filename", () => {
-  // If Paperless ever returned a filename containing a slash, it must
-  // not become an extra path segment.
+  // A filename containing a slash must not become an extra path segment.
   const uri = buildDocumentResourceUri(7, "sub/dir/file.pdf");
-  assert.equal(uri, "paperless://document/7/sub%2Fdir%2Ffile.pdf");
+  const url = new URL(uri);
+  assert.equal(url.pathname, "/7/download");
+  assert.equal(url.searchParams.get("filename"), "sub/dir/file.pdf");
 });
 
 test("buildDocumentResourceUri preserves unicode filenames", () => {
-  const uri = buildDocumentResourceUri(1, "Rechnüng — März.pdf");
-  // Roundtrip via decodeURIComponent should recover the original name.
-  const path = uri.replace("paperless://document/1/", "");
-  assert.equal(decodeURIComponent(path), "Rechnüng — März.pdf");
+  const original = "Rechnüng — März.pdf";
+  const uri = buildDocumentResourceUri(1, original);
+  // Roundtrip via URL parsing should recover the original name.
+  const url = new URL(uri);
+  assert.equal(url.searchParams.get("filename"), original);
 });
 
 test("buildDocumentResourceUri produces a valid URL", () => {
-  // Sanity: the constructed URI must parse via WHATWG URL.
   const uri = buildDocumentResourceUri(1, "Some File.pdf");
   assert.doesNotThrow(() => new URL(uri));
 });
 
-test("buildThumbnailResourceUri uses the paperless:// scheme with id and .webp", () => {
-  assert.equal(buildThumbnailResourceUri(1), "paperless://thumbnail/1.webp");
-  assert.equal(buildThumbnailResourceUri(123), "paperless://thumbnail/123.webp");
+test("buildThumbnailResourceUri mirrors the REST thumb path", () => {
+  assert.equal(buildThumbnailResourceUri(1), "paperless://documents/1/thumb");
+  assert.equal(
+    buildThumbnailResourceUri(123),
+    "paperless://documents/123/thumb"
+  );
 });
 
 test("buildThumbnailResourceUri produces a valid URL", () => {

--- a/src/tools/utils/resourceUri.test.ts
+++ b/src/tools/utils/resourceUri.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "./resourceUri";
+
+test("buildDocumentResourceUri uses the paperless:// scheme", () => {
+  const uri = buildDocumentResourceUri(1, "doc.pdf");
+  assert.match(uri, /^paperless:\/\/document\//);
+});
+
+test("buildDocumentResourceUri encodes filenames with spaces", () => {
+  const uri = buildDocumentResourceUri(1, "invoice 2026.pdf");
+  assert.equal(uri, "paperless://document/1/invoice%202026.pdf");
+});
+
+test("buildDocumentResourceUri encodes RFC-3986 reserved characters", () => {
+  const uri = buildDocumentResourceUri(42, "weird ?#&=+name.pdf");
+  // encodeURIComponent encodes ?, #, &, =, +, and spaces — none of these
+  // should leak through and be mis-parsed as URI structure.
+  assert.doesNotMatch(uri, /[?#]/);
+  assert.match(uri, /^paperless:\/\/document\/42\//);
+});
+
+test("buildDocumentResourceUri encodes path separators inside filename", () => {
+  // If Paperless ever returned a filename containing a slash, it must
+  // not become an extra path segment.
+  const uri = buildDocumentResourceUri(7, "sub/dir/file.pdf");
+  assert.equal(uri, "paperless://document/7/sub%2Fdir%2Ffile.pdf");
+});
+
+test("buildDocumentResourceUri preserves unicode filenames", () => {
+  const uri = buildDocumentResourceUri(1, "Rechnüng — März.pdf");
+  // Roundtrip via decodeURIComponent should recover the original name.
+  const path = uri.replace("paperless://document/1/", "");
+  assert.equal(decodeURIComponent(path), "Rechnüng — März.pdf");
+});
+
+test("buildDocumentResourceUri produces a valid URL", () => {
+  // Sanity: the constructed URI must parse via WHATWG URL.
+  const uri = buildDocumentResourceUri(1, "Some File.pdf");
+  assert.doesNotThrow(() => new URL(uri));
+});
+
+test("buildThumbnailResourceUri uses the paperless:// scheme with id and .webp", () => {
+  assert.equal(buildThumbnailResourceUri(1), "paperless://thumbnail/1.webp");
+  assert.equal(buildThumbnailResourceUri(123), "paperless://thumbnail/123.webp");
+});
+
+test("buildThumbnailResourceUri produces a valid URL", () => {
+  assert.doesNotThrow(() => new URL(buildThumbnailResourceUri(99)));
+});

--- a/src/tools/utils/resourceUri.test.ts
+++ b/src/tools/utils/resourceUri.test.ts
@@ -10,38 +10,39 @@ test("buildDocumentResourceUri mirrors the REST download path", () => {
   assert.match(uri, /^paperless:\/\/documents\/1\/download(\?|$)/);
 });
 
-test("buildDocumentResourceUri puts the filename in a query parameter", () => {
+test("buildDocumentResourceUri is canonical without filenames", () => {
   const uri = buildDocumentResourceUri(1, "invoice 2026.pdf");
-  assert.equal(
-    uri,
-    "paperless://documents/1/download?filename=invoice%202026.pdf"
-  );
+  assert.equal(uri, "paperless://documents/1/download");
 });
 
-test("buildDocumentResourceUri encodes RFC-3986 reserved chars in the filename", () => {
+test("buildDocumentResourceUri ignores reserved chars in legacy filename input", () => {
   const uri = buildDocumentResourceUri(42, "weird ?#&=+name.pdf");
   const url = new URL(uri);
-  // The path stays canonical — only the literal `?` that separates
-  // path from query is allowed; nothing from the filename should
-  // bleed into the path or break query parsing.
   assert.equal(url.pathname, "/42/download");
-  assert.equal(url.searchParams.get("filename"), "weird ?#&=+name.pdf");
+  assert.equal(url.search, "");
 });
 
-test("buildDocumentResourceUri encodes path separators inside filename", () => {
+test("buildDocumentResourceUri ignores path separators in legacy filename input", () => {
   // A filename containing a slash must not become an extra path segment.
   const uri = buildDocumentResourceUri(7, "sub/dir/file.pdf");
   const url = new URL(uri);
   assert.equal(url.pathname, "/7/download");
-  assert.equal(url.searchParams.get("filename"), "sub/dir/file.pdf");
+  assert.equal(url.search, "");
 });
 
-test("buildDocumentResourceUri preserves unicode filenames", () => {
+test("buildDocumentResourceUri keeps unicode filenames out of the URI", () => {
   const original = "Rechnüng — März.pdf";
   const uri = buildDocumentResourceUri(1, original);
-  // Roundtrip via URL parsing should recover the original name.
   const url = new URL(uri);
-  assert.equal(url.searchParams.get("filename"), original);
+  assert.equal(url.pathname, "/1/download");
+  assert.equal(url.search, "");
+});
+
+test("buildDocumentResourceUri preserves original download intent", () => {
+  assert.equal(
+    buildDocumentResourceUri(1, { original: true }),
+    "paperless://documents/1/download?original=true"
+  );
 });
 
 test("buildDocumentResourceUri produces a valid URL", () => {

--- a/src/tools/utils/resourceUri.ts
+++ b/src/tools/utils/resourceUri.ts
@@ -1,32 +1,33 @@
 /**
  * Resource URI builders for document/thumbnail downloads.
  *
- * MCP resource URIs are validated by Python MCP clients (pydantic) as
- * `AnyUrl` — they must be a valid URL or relative URL without a base.
- * Plain filenames or strings without a scheme fail this validation, so
- * we wrap them in a custom `paperless://` scheme that is always
- * well-formed regardless of filename content.
+ * URIs mirror the Paperless REST API paths under a custom `paperless://`
+ * scheme, so the same identifiers can later back proper MCP resources
+ * (`resources/list` / `resources/read`) without a second naming scheme.
+ *
+ * The scheme also keeps the URI well-formed regardless of filename
+ * content, which Python MCP clients (pydantic-validated) require.
  */
 
 /**
  * Builds a resource URI for a downloaded document.
  *
- * The original filename is preserved (URL-encoded) inside the URI path,
- * so clients that need the original name can still recover it.
+ * Mirrors `GET /api/documents/{id}/download/`. The original filename is
+ * preserved as a `filename` query parameter (URL-encoded) so clients
+ * that need the human-readable name can still recover it.
  */
 export function buildDocumentResourceUri(
   id: number,
   filename: string
 ): string {
-  return `paperless://document/${id}/${encodeURIComponent(filename)}`;
+  return `paperless://documents/${id}/download?filename=${encodeURIComponent(filename)}`;
 }
 
 /**
  * Builds a resource URI for a document thumbnail.
  *
- * Thumbnails have no meaningful filename, so we use a stable shape
- * derived from the document id alone.
+ * Mirrors `GET /api/documents/{id}/thumb/`.
  */
 export function buildThumbnailResourceUri(id: number): string {
-  return `paperless://thumbnail/${id}.webp`;
+  return `paperless://documents/${id}/thumb`;
 }

--- a/src/tools/utils/resourceUri.ts
+++ b/src/tools/utils/resourceUri.ts
@@ -1,0 +1,32 @@
+/**
+ * Resource URI builders for document/thumbnail downloads.
+ *
+ * MCP resource URIs are validated by Python MCP clients (pydantic) as
+ * `AnyUrl` — they must be a valid URL or relative URL without a base.
+ * Plain filenames or strings without a scheme fail this validation, so
+ * we wrap them in a custom `paperless://` scheme that is always
+ * well-formed regardless of filename content.
+ */
+
+/**
+ * Builds a resource URI for a downloaded document.
+ *
+ * The original filename is preserved (URL-encoded) inside the URI path,
+ * so clients that need the original name can still recover it.
+ */
+export function buildDocumentResourceUri(
+  id: number,
+  filename: string
+): string {
+  return `paperless://document/${id}/${encodeURIComponent(filename)}`;
+}
+
+/**
+ * Builds a resource URI for a document thumbnail.
+ *
+ * Thumbnails have no meaningful filename, so we use a stable shape
+ * derived from the document id alone.
+ */
+export function buildThumbnailResourceUri(id: number): string {
+  return `paperless://thumbnail/${id}.webp`;
+}

--- a/src/tools/utils/resourceUri.ts
+++ b/src/tools/utils/resourceUri.ts
@@ -1,26 +1,39 @@
 /**
  * Resource URI builders for document/thumbnail downloads.
  *
- * URIs mirror the Paperless REST API paths under a custom `paperless://`
- * scheme, so the same identifiers can later back proper MCP resources
- * (`resources/list` / `resources/read`) without a second naming scheme.
+ * URIs mirror document resources under a custom `paperless://` scheme, so the
+ * same identifiers can back MCP resources (`resources/list` / `resources/read`)
+ * without a second naming scheme.
  *
  * The scheme also keeps the URI well-formed regardless of filename
  * content, which Python MCP clients (pydantic-validated) require.
  */
 
 /**
+ * Optional flags for document download resource URIs.
+ */
+export interface DocumentResourceUriOptions {
+  original?: boolean;
+}
+
+/**
  * Builds a resource URI for a downloaded document.
  *
- * Mirrors `GET /api/documents/{id}/download/`. The original filename is
- * preserved as a `filename` query parameter (URL-encoded) so clients
- * that need the human-readable name can still recover it.
+ * The MCP resource URI is intentionally canonical and filename-free; filenames
+ * belong in resource metadata, while the URI identifies the fetchable content.
  */
 export function buildDocumentResourceUri(
   id: number,
-  filename: string
+  optionsOrFilename?: DocumentResourceUriOptions | string
 ): string {
-  return `paperless://documents/${id}/download?filename=${encodeURIComponent(filename)}`;
+  const options =
+    typeof optionsOrFilename === "string" ? {} : optionsOrFilename || {};
+  const params = new URLSearchParams();
+  if (options.original) {
+    params.set("original", "true");
+  }
+  const query = params.toString();
+  return `paperless://documents/${id}/download${query ? `?${query}` : ""}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #90.

Adds MCP `resources/list` and `resources/read` for documents:
- `paperless://documents/{id}/download` — file content
- `paperless://documents/{id}/thumb` — thumbnail

`download_document` and `get_document_thumbnail` now return a resource reference (URI + mime type) instead of an inline base64 blob — clients fetch the bytes via `resources/read`. Keeps large binaries out of conversation context for clients that accumulate tool results (the n8n LangChain agent use case described in #90).

Download URI accepts `?original=true`.

**Stacked on #86** — the diff currently includes #86's commit too; once #86 lands, the GitHub diff will auto-shrink to just this work.

## Two pre-existing issues a Codex adversarial review surfaced

Not introduced by this PR, but worth flagging since this PR exposes both via new code paths. Happy to fold fixes into this PR or open follow-ups — your call.

1. **[medium] Paperless v3+ 406 on binary fetches.**
   `PaperlessAPI.downloadDocument` and `getThumbnail` don't apply `PAPERLESS_API_VERSION` to the `Accept` header. On Paperless-ngx v3+, these can return 406 — both the existing tool path and the new `resources/read` path hit it.

2. **[high] SSE `/messages` channel only validates `sessionId`.**
   In `src/index.ts`, the `/sse` endpoint checks the bearer token, but JSON-RPC requests are posted to `/messages`, which only trusts the `sessionId`. Anyone who gets a live session ID can invoke tools (and now `resources/read`) with the token bound at stream-open time, without re-presenting auth. Pre-existing security gap in the SSE flow.

## Commits

- `a69e017` — feat: add MCP resources support for documents
- `a866532` — fix: cap `resources/list` to first page of documents (avoids unbounded payloads on large libraries — adversarial-review finding)

## Test plan

- [x] `npm test` (15 tests pass, including 5 new resource tests)
- [x] `npm run build` clean
- [x] `resourceUri.test.ts` runs directly (9 tests — note the existing globstar issue in the `npm test` script that's unrelated to this PR)
- [ ] Manual smoke test with a real MCP client (`resources/list`, `resources/read`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents exposed as paperless:// resource URIs for download and thumbnails; resources are discoverable via listing and lazily fetched on demand.
  * Downloads support an original=true option to retrieve original-format files.

* **Improvements**
  * Resource metadata now includes human-readable filenames for easier identification.

* **Bug Fixes**
  * Resource URIs are now canonical and consistently formatted for reliable client handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baruchiro/paperless-mcp/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->