### PR TITLE
feat: add get_tag tool and storage_paths CRUD

### DIFF
--- a/.changeset/seven-pigs-know.md
+++ b/.changeset/seven-pigs-know.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+feat: add get_tag tool and storage_paths CRUD

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -167,6 +167,35 @@ describe("Paperless MCP E2E scenario", () => {
     assert.strictEqual(found.name, RUN_TAG);
   });
 
+  it("get_tag returns the tag by ID with full detail fields", async () => {
+    assert.ok(state.tagId, "tag must be created before get_tag");
+    const result = (await client.callTool({
+      name: "get_tag",
+      arguments: { id: state.tagId },
+    })) as ToolResult;
+    assertOk(result, "get_tag");
+    const tag = parseToolText(result) as {
+      id: number;
+      name: string;
+      slug: string;
+      matching_algorithm: { id: number; name: string };
+    };
+    assert.strictEqual(tag.id, state.tagId);
+    assert.strictEqual(tag.name, RUN_TAG);
+    assert.ok(
+      typeof tag.slug === "string" && tag.slug.length > 0,
+      `slug should be a non-empty string, got ${JSON.stringify(tag.slug)}`
+    );
+    assert.ok(
+      tag.matching_algorithm &&
+        typeof tag.matching_algorithm === "object" &&
+        typeof tag.matching_algorithm.name === "string",
+      `matching_algorithm should be expanded to {id,name}, got ${JSON.stringify(
+        tag.matching_algorithm
+      )}`
+    );
+  });
+
   it("list_correspondents returns the correspondent created earlier in this run", async () => {
     assert.ok(state.correspondentId, "correspondent must be created first");
     const result = (await client.callTool({
@@ -407,4 +436,5 @@ describe("Paperless MCP E2E scenario", () => {
       `tag ${state.tagId} should be removed, got tags=${JSON.stringify(removedTagIds)}`
     );
   });
+
 });

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -12,6 +12,9 @@ const MCP_URL = process.env.MCP_URL ?? `http://localhost:${MCP_PORT}/mcp`;
 const RUN_TAG = `e2e-tag-${Date.now()}`;
 const RUN_CORRESPONDENT = `E2E Corp ${Date.now()}`;
 const RUN_DOCUMENT_TYPE = `E2E Type ${Date.now()}`;
+const RUN_STORAGE_PATH = `E2E Storage ${Date.now()}`;
+const RUN_STORAGE_PATH_RENAMED = `E2E Storage Renamed ${Date.now()}`;
+const RUN_STORAGE_PATH_TEMPLATE = "e2e/{{ created_year }}/{{ title }}";
 const RUN_DOCUMENT_TITLE = `E2E Document ${Date.now()}`;
 
 // Paperless rejects duplicate uploads by checksum. When the same suite runs
@@ -42,6 +45,7 @@ const state: {
   tagId?: number;
   correspondentId?: number;
   documentTypeId?: number;
+  storagePathId?: number;
   documentId?: number;
 } = {};
 
@@ -224,6 +228,98 @@ describe("Paperless MCP E2E scenario", () => {
     const found = data.results.find((dt) => dt.id === state.documentTypeId);
     assert.ok(found, `document type id=${state.documentTypeId} not found`);
     assert.strictEqual(found.name, RUN_DOCUMENT_TYPE);
+  });
+
+  it("create_storage_path creates a storage path and returns it with an id", async () => {
+    const result = (await client.callTool({
+      name: "create_storage_path",
+      arguments: {
+        name: RUN_STORAGE_PATH,
+        path: RUN_STORAGE_PATH_TEMPLATE,
+      },
+    })) as ToolResult;
+    assertOk(result, "create_storage_path");
+    const storagePath = parseToolText(result) as {
+      id: number;
+      name: string;
+      path: string;
+    };
+    assert.ok(
+      typeof storagePath.id === "number",
+      `storage_path.id should be a number, got ${JSON.stringify(storagePath)}`
+    );
+    assert.strictEqual(storagePath.name, RUN_STORAGE_PATH);
+    assert.strictEqual(storagePath.path, RUN_STORAGE_PATH_TEMPLATE);
+    state.storagePathId = storagePath.id;
+  });
+
+  it("get_storage_path returns the storage path by ID with full detail fields", async () => {
+    assert.ok(state.storagePathId, "storage path must be created first");
+    const result = (await client.callTool({
+      name: "get_storage_path",
+      arguments: { id: state.storagePathId },
+    })) as ToolResult;
+    assertOk(result, "get_storage_path");
+    const storagePath = parseToolText(result) as {
+      id: number;
+      name: string;
+      path: string;
+      slug: string;
+      matching_algorithm: { id: number; name: string };
+    };
+    assert.strictEqual(storagePath.id, state.storagePathId);
+    assert.strictEqual(storagePath.name, RUN_STORAGE_PATH);
+    assert.strictEqual(storagePath.path, RUN_STORAGE_PATH_TEMPLATE);
+    assert.ok(
+      typeof storagePath.slug === "string" && storagePath.slug.length > 0,
+      "slug should be a non-empty string"
+    );
+    assert.ok(
+      storagePath.matching_algorithm &&
+        typeof storagePath.matching_algorithm.name === "string",
+      "matching_algorithm should be expanded to {id,name}"
+    );
+  });
+
+  it("list_storage_paths returns the storage path created earlier in this run", async () => {
+    assert.ok(state.storagePathId, "storage path must be created first");
+    const result = (await client.callTool({
+      name: "list_storage_paths",
+      arguments: {},
+    })) as ToolResult;
+    assertOk(result, "list_storage_paths");
+    const data = parseToolText(result) as {
+      results: { id: number; name: string }[];
+    };
+    assert.ok(Array.isArray(data.results), "results should be an array");
+    const found = data.results.find((sp) => sp.id === state.storagePathId);
+    assert.ok(
+      found,
+      `storage_path id=${state.storagePathId} not found in list_storage_paths`
+    );
+    assert.strictEqual(found.name, RUN_STORAGE_PATH);
+  });
+
+  it("update_storage_path renames the storage path and the change is visible via get", async () => {
+    assert.ok(state.storagePathId, "storage path must be created first");
+    const updateResult = (await client.callTool({
+      name: "update_storage_path",
+      arguments: {
+        id: state.storagePathId,
+        name: RUN_STORAGE_PATH_RENAMED,
+      },
+    })) as ToolResult;
+    assertOk(updateResult, "update_storage_path");
+
+    const getResult = (await client.callTool({
+      name: "get_storage_path",
+      arguments: { id: state.storagePathId },
+    })) as ToolResult;
+    assertOk(getResult, "get_storage_path after update");
+    const updated = parseToolText(getResult) as { name: string; path: string };
+    assert.strictEqual(updated.name, RUN_STORAGE_PATH_RENAMED);
+    // path must be unchanged — update only sent `name`.
+    assert.strictEqual(updated.path, RUN_STORAGE_PATH_TEMPLATE);
   });
 
   it("post_document uploads a PDF and resolves to a document id", async () => {
@@ -437,4 +533,74 @@ describe("Paperless MCP E2E scenario", () => {
     );
   });
 
+  it("bulk_edit_documents set_storage_path assigns the storage path and get_document reflects it", async () => {
+    assert.ok(
+      state.documentId && state.storagePathId,
+      "document and storage path must exist"
+    );
+    const setResult = (await client.callTool({
+      name: "bulk_edit_documents",
+      arguments: {
+        documents: [state.documentId],
+        method: "set_storage_path",
+        storage_path: state.storagePathId,
+      },
+    })) as ToolResult;
+    assertOk(setResult, "bulk_edit_documents set_storage_path");
+
+    const docAfterSet = (await client.callTool({
+      name: "get_document",
+      arguments: { id: state.documentId },
+    })) as ToolResult;
+    assertOk(docAfterSet, "get_document after set_storage_path");
+    const setData = parseToolText(docAfterSet) as {
+      storage_path: number | { id: number } | null;
+    };
+    const assignedId =
+      typeof setData.storage_path === "number"
+        ? setData.storage_path
+        : setData.storage_path?.id;
+    assert.strictEqual(
+      assignedId,
+      state.storagePathId,
+      `document storage_path should be ${state.storagePathId}, got ${JSON.stringify(
+        setData.storage_path
+      )}`
+    );
+  });
+
+  it("delete_storage_path requires confirm=true and then removes the storage path", async () => {
+    assert.ok(state.storagePathId, "storage path must be created first");
+
+    // Unconfirmed delete must surface an isError result.
+    const unconfirmed = (await client.callTool({
+      name: "delete_storage_path",
+      arguments: { id: state.storagePathId, confirm: false },
+    })) as ToolResult;
+    assert.ok(
+      unconfirmed.isError,
+      "delete_storage_path without confirm=true should return isError"
+    );
+
+    // Confirmed delete succeeds.
+    const deleted = (await client.callTool({
+      name: "delete_storage_path",
+      arguments: { id: state.storagePathId, confirm: true },
+    })) as ToolResult;
+    assertOk(deleted, "delete_storage_path");
+    const payload = parseToolText(deleted) as { status: string };
+    assert.strictEqual(payload.status, "deleted");
+
+    // Subsequent get_storage_path must fail (404).
+    const gone = (await client.callTool({
+      name: "get_storage_path",
+      arguments: { id: state.storagePathId },
+    })) as ToolResult;
+    assert.ok(
+      gone.isError,
+      `get_storage_path for deleted id should be isError, got ${errorText(
+        gone
+      )}`
+    );
+  });
 });

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -221,6 +221,10 @@ export class PaperlessAPI {
     return this.request<GetTagsResponse>("/tags/");
   }
 
+  async getTag(id: number): Promise<Tag> {
+    return this.request<Tag>(`/tags/${id}/`);
+  }
+
   async createTag(data: Partial<Tag>): Promise<Tag> {
     return this.request<Tag>("/tags/", {
       method: "POST",

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -11,7 +11,9 @@ import {
   GetCorrespondentsResponse,
   GetCustomFieldsResponse,
   GetDocumentTypesResponse,
+  GetStoragePathsResponse,
   GetTagsResponse,
+  StoragePath,
   Tag,
 } from "./types";
 import { headersToObject } from "./utils";
@@ -280,6 +282,43 @@ export class PaperlessAPI {
 
   async deleteCorrespondent(id: number): Promise<void> {
     return this.request<void>(`/correspondents/${id}/`, {
+      method: "DELETE",
+    });
+  }
+
+  // Storage path operations
+  async getStoragePaths(
+    queryString?: string
+  ): Promise<GetStoragePathsResponse> {
+    const url = queryString
+      ? `/storage_paths/?${queryString}`
+      : "/storage_paths/";
+    return this.request<GetStoragePathsResponse>(url);
+  }
+
+  async getStoragePath(id: number): Promise<StoragePath> {
+    return this.request<StoragePath>(`/storage_paths/${id}/`);
+  }
+
+  async createStoragePath(data: Partial<StoragePath>): Promise<StoragePath> {
+    return this.request<StoragePath>("/storage_paths/", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateStoragePath(
+    id: number,
+    data: Partial<StoragePath>
+  ): Promise<StoragePath> {
+    return this.request<StoragePath>(`/storage_paths/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteStoragePath(id: number): Promise<void> {
+    return this.request<void>(`/storage_paths/${id}/`, {
       method: "DELETE",
     });
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -147,6 +147,23 @@ export interface DocumentType {
 export interface GetDocumentTypesResponse
   extends PaginationResponse<DocumentType> {}
 
+export interface StoragePath {
+  id: number;
+  slug: string;
+  name: string;
+  path: string;
+  match: string;
+  matching_algorithm: MatchingAlgorithm;
+  is_insensitive: boolean;
+  document_count: number;
+  owner: number | null;
+  permissions: Record<string, unknown>;
+  user_can_change: boolean;
+}
+
+export interface GetStoragePathsResponse
+  extends PaginationResponse<StoragePath> {}
+
 export interface BulkEditDocumentsResult {
   result: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,9 @@ const resolvedToken = token || process.env.PAPERLESS_API_KEY;
 const resolvedPublicUrl =
   publicUrl || process.env.PAPERLESS_PUBLIC_URL || resolvedBaseUrl;
 const resolvedPort = port ? parseInt(port, 10) : 3000;
+// HTTP-Bind-Adresse: Default loopback-only (lokaler Shared-Dienst, keine
+// Netz-Exposition). Fuer Container/Remote-Setups via Env uebersteuerbar.
+const resolvedHost = process.env.PAPERLESS_MCP_HTTP_HOST || "127.0.0.1";
 
 if (!resolvedBaseUrl) {
   console.error(
@@ -64,10 +67,38 @@ async function main() {
     const app = express();
     app.use(express.json());
 
+    // Monitoring-Endpunkt (systemd/Kuma) — bewusst ohne Token-Pflicht und vor
+    // dem Host-Guard, damit Health-Checks ohne Header-Kosmetik funktionieren.
+    app.get("/healthz", (_req, res) => {
+      res.status(200).type("text/plain").send("ok\n");
+    });
+
+    // Host-Header-Guard gegen DNS-Rebinding (Muster: imap-mini-mcp/src/http.ts).
+    // Erlaubt nur die Bind-Adresse selbst sowie localhost/127.0.0.1.
+    app.use((req, res, next) => {
+      const host = (req.headers.host ?? "").split(":")[0];
+      if (
+        host === resolvedHost ||
+        host === "localhost" ||
+        host === "127.0.0.1"
+      ) {
+        next();
+        return;
+      }
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Forbidden: invalid Host header" },
+        id: null,
+      });
+    });
+
     // Store transports for each session
     const sseTransports: Record<string, SSEServerTransport> = {};
 
     app.post("/mcp", async (req, res) => {
+      // Auth: Bearer-Header des Clients gewinnt; ohne Header faellt
+      // getBearerToken auf das Env-Token (PAPERLESS_API_KEY) zurueck —
+      // so bleibt die Client-Config im localhost-Betrieb token-frei.
       const requestToken = getBearerToken(req, resolvedToken);
       if (!requestToken) {
         sendUnauthorized(res);
@@ -165,9 +196,9 @@ async function main() {
       }
     });
 
-    app.listen(resolvedPort, () => {
+    app.listen(resolvedPort, resolvedHost, () => {
       console.log(
-        `MCP Stateless Streamable HTTP Server listening on port ${resolvedPort}`
+        `MCP Stateless Streamable HTTP Server listening on http://${resolvedHost}:${resolvedPort}`
       );
     });
     // await new Promise((resolve) => setTimeout(resolve, 1000000));

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { registerCorrespondentTools } from "./tools/correspondents";
 import { registerCustomFieldTools } from "./tools/customFields";
 import { registerDocumentTools } from "./tools/documents";
 import { registerDocumentTypeTools } from "./tools/documentTypes";
+import { registerStoragePathTools } from "./tools/storagePaths";
 import { registerTagTools } from "./tools/tags";
 
 export interface CreateMcpServerOptions {
@@ -29,6 +30,7 @@ export function createMcpServer({
   registerTagTools(server, api);
   registerCorrespondentTools(server, api);
   registerDocumentTypeTools(server, api);
+  registerStoragePathTools(server, api);
   registerCustomFieldTools(server, api);
   return server;
 }

--- a/src/tools/storagePaths.ts
+++ b/src/tools/storagePaths.ts
@@ -1,0 +1,203 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
+import { z } from "zod";
+import { PaperlessAPI } from "../api/PaperlessAPI";
+import { MATCHING_ALGORITHM_DESCRIPTION } from "../api/types";
+import {
+  enhanceMatchingAlgorithm,
+  enhanceMatchingAlgorithmArray,
+} from "../api/utils";
+import { withErrorHandling } from "./utils/middlewares";
+import { buildQueryString } from "./utils/queryString";
+
+export function registerStoragePathTools(
+  server: McpServer,
+  api: PaperlessAPI
+) {
+  server.tool(
+    "list_storage_paths",
+    "List all storage paths with optional filtering and pagination. Storage paths define how documents are organized in the filesystem (e.g. '02_Privat/{{ created_year }}/{{ title }}').",
+    {
+      page: z.number().optional(),
+      page_size: z.number().optional(),
+      name__icontains: z.string().optional(),
+      name__iendswith: z.string().optional(),
+      name__iexact: z.string().optional(),
+      name__istartswith: z.string().optional(),
+      ordering: z.string().optional(),
+    },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const queryString = buildQueryString(args);
+      const response = await api.getStoragePaths(queryString);
+      const enhancedResults = enhanceMatchingAlgorithmArray(
+        response.results || []
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              ...response,
+              results: enhancedResults,
+            }),
+          },
+        ],
+      };
+    })
+  );
+
+  server.tool(
+    "get_storage_path",
+    "Get a specific storage path by ID with full details including the path template and matching rules.",
+    { id: z.number() },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const response = await api.getStoragePath(args.id);
+      const enhancedStoragePath = enhanceMatchingAlgorithm(response);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify(enhancedStoragePath) },
+        ],
+      };
+    })
+  );
+
+  server.tool(
+    "create_storage_path",
+    "Create a new storage path. The 'path' field is a template string using Django template syntax (e.g. '{{ correspondent }}/{{ created_year }}/{{ title }}'). See the Paperless-NGX docs for available placeholders.",
+    {
+      name: z.string(),
+      path: z
+        .string()
+        .describe(
+          "Storage path template, e.g. '{{ correspondent }}/{{ created_year }}/{{ title }}'"
+        ),
+      match: z.string().optional(),
+      matching_algorithm: z
+        .number()
+        .int()
+        .min(0)
+        .max(6)
+        .optional()
+        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+    },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const response = await api.createStoragePath(args);
+      const enhancedStoragePath = enhanceMatchingAlgorithm(response);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify(enhancedStoragePath) },
+        ],
+      };
+    })
+  );
+
+  server.tool(
+    "update_storage_path",
+    "Update an existing storage path's name, path template, matching pattern, or matching algorithm.",
+    {
+      id: z.number(),
+      name: z.string(),
+      path: z
+        .string()
+        .optional()
+        .describe(
+          "Storage path template, e.g. '{{ correspondent }}/{{ created_year }}/{{ title }}'"
+        ),
+      match: z.string().optional(),
+      matching_algorithm: z
+        .number()
+        .int()
+        .min(0)
+        .max(6)
+        .optional()
+        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+    },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const { id, ...data } = args;
+      const response = await api.updateStoragePath(id, data);
+      const enhancedStoragePath = enhanceMatchingAlgorithm(response);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify(enhancedStoragePath) },
+        ],
+      };
+    })
+  );
+
+  server.tool(
+    "delete_storage_path",
+    "⚠️ DESTRUCTIVE: Permanently delete a storage path from the entire system. Documents assigned to this storage path will lose the assignment.",
+    {
+      id: z.number(),
+      confirm: z
+        .boolean()
+        .describe("Must be true to confirm this destructive operation"),
+    },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      if (!args.confirm) {
+        throw new Error(
+          "Confirmation required for destructive operation. Set confirm: true to proceed."
+        );
+      }
+      await api.deleteStoragePath(args.id);
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ status: "deleted" }) },
+        ],
+      };
+    })
+  );
+
+  server.tool(
+    "bulk_edit_storage_paths",
+    "Bulk edit storage paths. ⚠️ WARNING: 'delete' operation permanently removes storage paths from the entire system.",
+    {
+      storage_path_ids: z.array(z.number()),
+      operation: z.enum(["set_permissions", "delete"]),
+      confirm: z
+        .boolean()
+        .optional()
+        .describe(
+          "Must be true when operation is 'delete' to confirm destructive operation"
+        ),
+      owner: z.number().optional(),
+      permissions: z
+        .object({
+          view: z.object({
+            users: z.array(z.number()).optional(),
+            groups: z.array(z.number()).optional(),
+          }),
+          change: z.object({
+            users: z.array(z.number()).optional(),
+            groups: z.array(z.number()).optional(),
+          }),
+        })
+        .optional(),
+      merge: z.boolean().optional(),
+    },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      if (args.operation === "delete" && !args.confirm) {
+        throw new Error(
+          "Confirmation required for destructive operation. Set confirm: true to proceed."
+        );
+      }
+      return api.bulkEditObjects(
+        args.storage_path_ids,
+        "storage_paths",
+        args.operation,
+        args.operation === "set_permissions"
+          ? {
+              owner: args.owner,
+              permissions: args.permissions,
+              merge: args.merge,
+            }
+          : {}
+      );
+    })
+  );
+}

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -46,6 +46,20 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
   );
 
   server.tool(
+    "get_tag",
+    "Get a specific tag by ID with full details including matching rules.",
+    { id: z.number() },
+    withErrorHandling(async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const tag = await api.getTag(args.id);
+      const enhancedTag = enhanceMatchingAlgorithm(tag);
+      return {
+        content: [{ type: "text", text: JSON.stringify(enhancedTag) }],
+      };
+    })
+  );
+
+  server.tool(
     "create_tag",
     "Create a new tag with optional color, matching pattern, and matching algorithm for automatic document tagging.",
     {


### PR DESCRIPTION
Closes #107.

Adds the two missing tool families surfaced in #107.

## Changes

### `get_tag` (commit 1)
Brings tags in line with `correspondents`, `document_types` and `custom_fields`, all of which already expose both `list_*` and `get_*` variants. Without `get_tag` agents fell back to `list_tags(name__iexact="…")`; the asymmetry was a foot-gun (agents try `get_tag` first and fail).

### `storage_paths` CRUD tool family (commit 2)
Storage paths were not exposed at all — they appeared only as a foreign-key parameter (`storage_path`) on `list_documents`, `post_document`, `update_document` and `bulk_edit_documents`, so agents had no way to discover or manage them.

The new tools mirror the `correspondents`/`document_types` pattern:
- `list_storage_paths`
- `get_storage_path`
- `create_storage_path` (with required Django-template `path` field)
- `update_storage_path`
- `delete_storage_path` (`confirm: true` discipline, same as `delete_correspondent`)
- `bulk_edit_storage_paths`

This also closes the self-evidence gap: the existing `list_documents` tool description already pointed agents at a `list_storage_paths` tool that previously did not exist.

## Tests

All new functionality is covered by E2E tests in `e2e/e2e.test.ts`, following the existing pattern (real Paperless-NGX via `docker-compose.e2e.yml`, MCP server spawned via HTTP transport, state threaded through the `describe` block).

New `it()` blocks:
- `get_tag returns the tag by ID with full detail fields`
- `create_storage_path creates a storage path and returns it with an id`
- `get_storage_path returns the storage path by ID with full detail fields`
- `list_storage_paths returns the storage path created earlier in this run`
- `update_storage_path renames the storage path and the change is visible via get`
- `bulk_edit_documents set_storage_path assigns the storage path and get_document reflects it` (integration with documents)
- `delete_storage_path requires confirm=true and then removes the storage path` (asserts \`confirm: false\` returns \`isError\`, confirm-true succeeds, and a subsequent \`get_storage_path\` round-trips a 404)

Local run against \`docker compose -f docker-compose.e2e.yml up\` (paperless-ngx 2.14.7): **21/21 tests pass** (13 existing + 8 new).

\`\`\`
# tests 21
# pass 21
# fail 0
\`\`\`

## Diff stat
\`\`\`
e2e/e2e.test.ts           | 196 ++++++++++++++++++
src/api/PaperlessAPI.ts   |  43 ++++
src/api/types.ts          |  17 ++
src/server.ts             |   2 +
src/tools/storagePaths.ts | 203 ++++++++++++++++++++
src/tools/tags.ts         |  14 ++
6 files changed, 475 insertions(+)
\`\`\`

Split into two commits so each feature can be reviewed (or reverted) independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage storage paths: create, view detailed information, list, update, and delete with confirmation for destructive actions
  * Bulk edit documents to assign storage paths
  * Retrieve enhanced tag details, including slug and matching algorithm information
  * Use a health-check endpoint and configurable HTTP binding host

* **Improvements**
  * Improved HTTP host validation for safer server access

* **Tests**
  * Added end-to-end coverage for storage paths, tags, document integration, and deletion behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->