### PR TITLE
Enable manual triggering of E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # Weekly run to catch drift against upstream paperless-ngx :latest.
     - cron: "0 8 * * 1"
+  workflow_dispatch:
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
Added support for manual workflow dispatch to the E2E test workflow, allowing developers to trigger end-to-end tests on demand without waiting for the scheduled weekly run.

## Changes
- Added `workflow_dispatch:` trigger to the E2E workflow configuration, enabling manual execution via the GitHub Actions UI or CLI

## Details
This change allows team members to manually run the E2E test suite at any time, which is useful for:
- Testing changes before merging to main
- Verifying fixes without waiting for the next scheduled run
- Debugging issues in a controlled manner

The existing scheduled weekly run (Mondays at 8 AM UTC) is preserved to continue catching drift against upstream paperless-ngx.

https://claude.ai/code/session_01DxjunYuZbFnY2ZEZpQhWoP