### PR TITLE
fix(security): authenticate HTTP mode by default and stop leaking token in logs

### DIFF
--- a/.changeset/secure-http-auth.md
+++ b/.changeset/secure-http-auth.md
@@ -1,0 +1,9 @@
+---
+"@baruchiro/paperless-mcp": major
+---
+
+Secure HTTP mode by default and stop leaking the API token in logs.
+
+**BREAKING CHANGE:** In HTTP mode, requests without an `Authorization: Bearer <token>` header are now rejected with `401 Unauthorized`. Previously they silently fell back to the server-configured `PAPERLESS_API_KEY`, which left the endpoint unauthenticated for anyone able to reach the port. To restore the old fallback behaviour (trusted/local networks only), start the server with the new `--no-auth` flag; it requires a server token to be configured. Client-supplied Bearer tokens and stdio mode are unchanged.
+
+Also stops logging the raw request `options` (which included the request body) on API errors; only `url`, `method`, and `status` are logged now.

--- a/README.md
+++ b/README.md
@@ -551,19 +551,28 @@ npm run start -- <baseUrl> <token> --http --port 3000
 
 #### Per-request API token (HTTP/Docker mode)
 
-In HTTP mode, clients can supply their own Paperless-NGX API token via the standard `Authorization` header instead of (or in addition to) the server-configured `PAPERLESS_API_KEY`. The client-supplied token takes precedence.
+In HTTP mode, clients authenticate by supplying a Paperless-NGX API token via the standard `Authorization` header:
 
 ```
 Authorization: Bearer <paperless-ngx-api-token>
 ```
 
-| Scenario | Token used |
-|---|---|
-| Client sends `Authorization: Bearer <tok>` | `<tok>` (client-supplied, takes precedence) |
-| No header, `PAPERLESS_API_KEY` env var set | `PAPERLESS_API_KEY` from env |
-| No header, no env var | `401 Unauthorized` |
+The token is passed straight through to Paperless-NGX, so each client's own Paperless permissions are enforced end-to-end. This lets a single server instance serve multiple users, each with their own token. The same behaviour applies to both `/mcp` and `/sse` endpoints.
 
-This allows a single server instance to serve multiple users, each authenticating with their own Paperless-NGX token. The same behaviour applies to both `/mcp` and `/sse` endpoints.
+> **⚠️ Breaking change in v2.0.0 — HTTP mode is now authenticated by default.**
+>
+> Previously, a request with no `Authorization` header silently fell back to the server-configured `PAPERLESS_API_KEY`, which left the HTTP endpoint open to anyone who could reach the port. As of v2.0.0, requests without a `Bearer` token are rejected with `401 Unauthorized`. The server token is **never** used for unauthenticated requests unless you explicitly opt in with `--no-auth`.
+
+| Scenario | `--no-auth` off (default) | `--no-auth` on |
+|---|---|---|
+| Client sends `Authorization: Bearer <tok>` | `<tok>` (client-supplied) | `<tok>` (client-supplied) |
+| No header, `PAPERLESS_API_KEY` / `--token` set | `401 Unauthorized` | server token |
+| No header, no server token | `401 Unauthorized` | `401 Unauthorized` |
+
+**Migrating from v1.x:** if you relied on the old fallback (a single shared `PAPERLESS_API_KEY` with clients that don't send a token), you have two options:
+
+1. **Recommended:** have each client send `Authorization: Bearer <paperless-token>`.
+2. **Restore the old behaviour** (trusted/local networks only): start the server with the `--no-auth` flag, e.g. append it to the Docker `command`/args or your CLI invocation. This requires a server token (`PAPERLESS_API_KEY` or `--token`) to be configured.
 
 <details>
 <summary>Docker Deployment</summary>

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -53,7 +53,7 @@ export class PaperlessAPI {
         console.error({
           error: "Error executing request",
           url,
-          options,
+          method: options.method || "GET",
           status: response.status,
           response: body,
         });
@@ -77,7 +77,7 @@ export class PaperlessAPI {
         error: "Error executing request",
         message: error instanceof Error ? error.message : String(error),
         url,
-        options,
+        method: options.method || "GET",
         responseData: axios.isAxiosError(error) ? error.response?.data : undefined,
         status: axios.isAxiosError(error) ? error.response?.status : undefined,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 const { version } = require("../package.json") as { version: string };
 
 const {
-  values: { baseUrl, token, http: useHttp, port, publicUrl },
+  values: { baseUrl, token, http: useHttp, port, publicUrl, "no-auth": noAuth },
 } = parseArgs({
   options: {
     baseUrl: { type: "string" },
@@ -20,6 +20,7 @@ const {
     http: { type: "boolean", default: false },
     port: { type: "string" },
     publicUrl: { type: "string", default: "" },
+    "no-auth": { type: "boolean", default: false },
   },
   allowPositionals: true,
 });
@@ -32,7 +33,7 @@ const resolvedPort = port ? parseInt(port, 10) : 3000;
 
 if (!resolvedBaseUrl) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
@@ -42,10 +43,19 @@ if (!resolvedBaseUrl) {
 
 if (!useHttp && !resolvedToken) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
+  );
+  process.exit(1);
+}
+
+if (noAuth && !resolvedToken) {
+  console.error(
+    "--no-auth allows unauthenticated requests to use the server's Paperless token, " +
+      "but no server token is configured. Provide --token <token> or set PAPERLESS_API_KEY, " +
+      "or drop --no-auth and have clients authenticate with 'Authorization: Bearer <token>'."
   );
   process.exit(1);
 }
@@ -61,6 +71,20 @@ function buildServer(requestToken: string) {
 
 async function main() {
   if (useHttp) {
+    if (noAuth) {
+      console.warn(
+        "[paperless-mcp] --no-auth is enabled: requests without an 'Authorization: Bearer' header " +
+          "will use the server's Paperless token. Only use this on a trusted/local network."
+      );
+    } else if (resolvedToken) {
+      console.warn(
+        "[paperless-mcp] BREAKING CHANGE (v2.0.0): a server token is configured, but unauthenticated " +
+          "requests will be REJECTED. Clients must send 'Authorization: Bearer <paperless-token>'. " +
+          "To restore the previous behaviour where unauthenticated requests use the server token, " +
+          "restart with the --no-auth flag (trusted/local networks only)."
+      );
+    }
+
     const app = express();
     app.use(express.json());
 
@@ -68,7 +92,10 @@ async function main() {
     const sseTransports: Record<string, SSEServerTransport> = {};
 
     app.post("/mcp", async (req, res) => {
-      const requestToken = getBearerToken(req, resolvedToken);
+      const requestToken = getBearerToken(req, {
+        fallbackToken: resolvedToken,
+        allowAnonymous: noAuth,
+      });
       if (!requestToken) {
         sendUnauthorized(res);
         return;
@@ -126,7 +153,10 @@ async function main() {
 
     app.get("/sse", async (req, res) => {
       console.log("SSE request received");
-      const requestToken = getBearerToken(req, resolvedToken);
+      const requestToken = getBearerToken(req, {
+        fallbackToken: resolvedToken,
+        allowAnonymous: noAuth,
+      });
       if (!requestToken) {
         sendUnauthorized(res);
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,16 +72,16 @@ function buildServer(requestToken: string) {
 async function main() {
   if (useHttp) {
     if (noAuth) {
-      console.warn(
+      console.log(
         "[paperless-mcp] --no-auth is enabled: requests without an 'Authorization: Bearer' header " +
           "will use the server's Paperless token. Only use this on a trusted/local network."
       );
     } else if (resolvedToken) {
-      console.warn(
-        "[paperless-mcp] BREAKING CHANGE (v2.0.0): a server token is configured, but unauthenticated " +
-          "requests will be REJECTED. Clients must send 'Authorization: Bearer <paperless-token>'. " +
-          "To restore the previous behaviour where unauthenticated requests use the server token, " +
-          "restart with the --no-auth flag (trusted/local networks only)."
+      console.log(
+        "[paperless-mcp] A server token is configured, but unauthenticated requests are rejected. " +
+          "Clients must send 'Authorization: Bearer <paperless-token>'. " +
+          "To use the server token for unauthenticated requests instead, restart with the --no-auth flag " +
+          "(trusted/local networks only)."
       );
     }
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type express from "express";
+import { getBearerToken } from "./server";
+
+function reqWith(authorization?: string): express.Request {
+  return {
+    headers: authorization ? { authorization } : {},
+  } as unknown as express.Request;
+}
+
+test("client Bearer token takes precedence over the server token", () => {
+  const token = getBearerToken(reqWith("Bearer client-token"), {
+    fallbackToken: "server-token",
+    allowAnonymous: true,
+  });
+  assert.equal(token, "client-token");
+});
+
+test("client Bearer token is used even when anonymous access is disabled", () => {
+  const token = getBearerToken(reqWith("Bearer client-token"), {
+    fallbackToken: "server-token",
+    allowAnonymous: false,
+  });
+  assert.equal(token, "client-token");
+});
+
+test("falls back to the server token only when anonymous access is allowed", () => {
+  const token = getBearerToken(reqWith(), {
+    fallbackToken: "server-token",
+    allowAnonymous: true,
+  });
+  assert.equal(token, "server-token");
+});
+
+test("no header without anonymous access yields no token (request is rejected)", () => {
+  const token = getBearerToken(reqWith(), {
+    fallbackToken: "server-token",
+    allowAnonymous: false,
+  });
+  assert.equal(token, undefined);
+});
+
+test("non-Bearer Authorization scheme never leaks the server token by default", () => {
+  const token = getBearerToken(reqWith("Token server-token"), {
+    fallbackToken: "server-token",
+    allowAnonymous: false,
+  });
+  assert.equal(token, undefined);
+});
+
+test("anonymous access with no configured server token yields no token", () => {
+  const token = getBearerToken(reqWith(), {
+    allowAnonymous: true,
+  });
+  assert.equal(token, undefined);
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,18 +64,19 @@ export function getBearerToken(
 }
 
 export function sendUnauthorized(res: express.Response): void {
+  // Log operator-facing guidance server-side; keep the wire response minimal so
+  // we don't echo configuration hints back to unauthenticated callers.
+  console.error(
+    "[paperless-mcp] Rejected request with no 'Authorization: Bearer <paperless-ngx-api-token>' header. " +
+      "As of v2.0.0, HTTP mode requires a per-request Bearer token and no longer falls back to the " +
+      "server-configured token for unauthenticated requests. Have clients send their Paperless-NGX API " +
+      "token as a Bearer token, or restart the server with --no-auth to use the server token for " +
+      "unauthenticated requests (trusted/local networks only)."
+  );
   res
     .status(401)
     .set("WWW-Authenticate", 'Bearer realm="paperless-mcp"')
-    .json({
-      error: "unauthorized",
-      message:
-        "Missing 'Authorization: Bearer <paperless-ngx-api-token>' header. " +
-        "As of v2.0.0, paperless-mcp requires a per-request Bearer token in HTTP mode and no longer " +
-        "silently falls back to the server-configured token for unauthenticated requests. " +
-        "Either send your Paperless-NGX API token as a Bearer token, or restart the server with " +
-        "the --no-auth flag to allow unauthenticated requests to use the server token (local/trusted networks only).",
-    });
+    .json({ error: "unauthorized" });
 }
 
 function buildInstructions(publicUrl: string): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,22 +35,47 @@ export function createMcpServer({
   return server;
 }
 
+export interface ResolveTokenOptions {
+  /**
+   * Server-configured token used as a fallback for unauthenticated requests.
+   * Only consulted when `allowAnonymous` is true.
+   */
+  fallbackToken?: string;
+  /**
+   * When true, requests without a `Bearer` header fall back to `fallbackToken`
+   * (the legacy behaviour). When false (the default in HTTP mode), a request
+   * without a `Bearer` header is rejected and never uses the server token.
+   */
+  allowAnonymous: boolean;
+}
+
 export function getBearerToken(
   req: express.Request,
-  fallbackToken?: string
+  options: ResolveTokenOptions
 ): string | undefined {
   const authHeader = req.headers["authorization"];
   if (authHeader && authHeader.startsWith("Bearer ")) {
     return authHeader.slice(7);
   }
-  return fallbackToken || undefined;
+  if (options.allowAnonymous) {
+    return options.fallbackToken || undefined;
+  }
+  return undefined;
 }
 
 export function sendUnauthorized(res: express.Response): void {
   res
     .status(401)
     .set("WWW-Authenticate", 'Bearer realm="paperless-mcp"')
-    .end();
+    .json({
+      error: "unauthorized",
+      message:
+        "Missing 'Authorization: Bearer <paperless-ngx-api-token>' header. " +
+        "As of v2.0.0, paperless-mcp requires a per-request Bearer token in HTTP mode and no longer " +
+        "silently falls back to the server-configured token for unauthenticated requests. " +
+        "Either send your Paperless-NGX API token as a Bearer token, or restart the server with " +
+        "the --no-auth flag to allow unauthenticated requests to use the server token (local/trusted networks only).",
+    });
 }
 
 function buildInstructions(publicUrl: string): string {


### PR DESCRIPTION
Closes #113.

Addresses both security issues reported in #113, and realigns the per-request token feature (#62 / #61) with its original intent: *not leaving the HTTP endpoint open to everyone*.

## Issue 1 — sensitive data in error logs

`PaperlessAPI.request()` logged the raw `options` object on every failed request. The reporter flagged this as a token leak; the token actually lived in `mergedHeaders` (not `options`), but `options.body` was being logged in full, which can contain document content / PII. Both `console.error` calls now log only `url`, `method`, and `status`.

## Issue 2 — HTTP endpoint unauthenticated by default

`getBearerToken()` silently fell back to the server-configured `PAPERLESS_API_KEY` when no `Authorization` header was present. Combined with the documented docker-compose example (which sets `PAPERLESS_API_KEY`), this left the `/mcp` and `/sse` endpoints open to anyone able to reach the port — the exact problem #61 was opened to solve.

**The fix makes HTTP mode authenticated by default:**
- No `Bearer` token → `401 Unauthorized`. The server token is **never** used for unauthenticated requests unless explicitly opted in.
- New `--no-auth` flag restores the old fallback behaviour (trusted/local networks only); it requires a server token to be configured, or the server exits with a clear message.
- Client-supplied Bearer tokens (the multi-tenant pass-through use case from #61) and stdio mode are **unchanged**.

| Scenario | `--no-auth` off (default) | `--no-auth` on |
|---|---|---|
| Client sends `Authorization: Bearer <tok>` | `<tok>` | `<tok>` |
| No header, server token set | `401` | server token |
| No header, no server token | `401` | `401` |

### Operator guidance
- On startup in HTTP mode, a plain log line explains the active auth posture and how to opt into `--no-auth`.
- On each `401`, the detailed migration/`--no-auth` guidance is written to the **server log**; the wire response stays minimal (`{ "error": "unauthorized" }` + `WWW-Authenticate`) so we don't echo config hints to unauthenticated callers.

> Note on status codes: this gate only checks for the *presence* of a Bearer token, so it issues `401` (no credentials). A *wrong* token isn't validated locally — it's passed through to Paperless-NGX, which returns its own `401`/`403` on the proxied call.

## Breaking change

This changes the default behaviour of HTTP mode, so it's shipped as a **major** version bump (changeset included). Anyone relying on the old shared-token fallback should either have clients send a Bearer token (recommended) or add `--no-auth`. The Dockerfile is intentionally left **secure by default** (no `--no-auth`), since it's the most network-exposed deployment. README updated with the new precedence table and a migration section.

## Tests
- New `src/server.test.ts` covering the token-resolution / fallback matrix.
- Full suite: 30/30 passing.

https://claude.ai/code/session_01AMjrdn3bbpMHnL4dqweGv7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMjrdn3bbpMHnL4dqweGv7)_