### PR TITLE
feat: Add archive_serial_number and custom_fields filters to list_documents

### DIFF
--- a/.changeset/list-documents-asn-custom-field-filters.md
+++ b/.changeset/list-documents-asn-custom-field-filters.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+Add `archive_serial_number`, `archive_serial_number__isnull`, `custom_field_query`, and `custom_fields__icontains` filters to the `list_documents` tool.

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -13,6 +13,11 @@ const RUN_TAG = `e2e-tag-${Date.now()}`;
 const RUN_CORRESPONDENT = `E2E Corp ${Date.now()}`;
 const RUN_DOCUMENT_TYPE = `E2E Type ${Date.now()}`;
 const RUN_DOCUMENT_TITLE = `E2E Document ${Date.now()}`;
+const RUN_CUSTOM_FIELD = `e2e_cf_${Date.now()}`;
+const RUN_CUSTOM_FIELD_VALUE = `cf-value-${Date.now()}`;
+// archive_serial_number is a unique uint32 in Paperless; derive an in-range
+// value from the run timestamp so the CLI and Docker passes use distinct ASNs.
+const RUN_ASN = Date.now() % 4294967295;
 
 // Paperless rejects duplicate uploads by checksum. When the same suite runs
 // twice against one Paperless instance (e.g. CLI then Docker in one CI job),
@@ -43,6 +48,7 @@ const state: {
   correspondentId?: number;
   documentTypeId?: number;
   documentId?: number;
+  customFieldId?: number;
   mailAccountId?: number;
   mailRuleId?: number;
 } = {};
@@ -530,6 +536,145 @@ describe("Paperless MCP E2E scenario", () => {
     assert.ok(
       !removedTagIds.includes(state.tagId),
       `tag ${state.tagId} should be removed, got tags=${JSON.stringify(removedTagIds)}`
+    );
+  });
+
+  it("create_custom_field creates a string field used by the filter tests", async () => {
+    const result = (await client.callTool({
+      name: "create_custom_field",
+      arguments: { name: RUN_CUSTOM_FIELD, data_type: "string" },
+    })) as ToolResult;
+    assertOk(result, "create_custom_field");
+    const field = parseToolText(result) as { id: number; name: string };
+    assert.ok(typeof field.id === "number", `field.id should be a number, got ${JSON.stringify(field)}`);
+    assert.strictEqual(field.name, RUN_CUSTOM_FIELD);
+    state.customFieldId = field.id;
+  });
+
+  it("update_document sets archive_serial_number and the custom field value", async () => {
+    assert.ok(state.documentId && state.customFieldId, "document and custom field must exist");
+    const result = (await client.callTool({
+      name: "update_document",
+      arguments: {
+        id: state.documentId,
+        archive_serial_number: RUN_ASN,
+        custom_fields: [{ field: state.customFieldId, value: RUN_CUSTOM_FIELD_VALUE }],
+      },
+    })) as ToolResult;
+    assertOk(result, "update_document");
+  });
+
+  it("list_documents filters by exact archive_serial_number", async () => {
+    assert.ok(state.documentId, "document must be uploaded first");
+    const match = (await client.callTool({
+      name: "list_documents",
+      arguments: { archive_serial_number: RUN_ASN },
+    })) as ToolResult;
+    assertOk(match, "list_documents archive_serial_number");
+    const matchData = parseToolText(match) as { results: Array<{ id: number }> };
+    assert.ok(
+      matchData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} not found filtering by archive_serial_number=${RUN_ASN}`
+    );
+
+    // A different ASN must not return our document, proving the filter discriminates.
+    const otherAsn = RUN_ASN === 0 ? 1 : RUN_ASN - 1;
+    const miss = (await client.callTool({
+      name: "list_documents",
+      arguments: { archive_serial_number: otherAsn },
+    })) as ToolResult;
+    assertOk(miss, "list_documents archive_serial_number (other)");
+    const missData = parseToolText(miss) as { results: Array<{ id: number }> };
+    assert.ok(
+      !missData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} should not match archive_serial_number=${otherAsn}`
+    );
+  });
+
+  it("list_documents filters by archive_serial_number__isnull", async () => {
+    assert.ok(state.documentId, "document must be uploaded first");
+    // Our document now has an ASN, so it must be excluded when isnull=true...
+    const isnullTrue = (await client.callTool({
+      name: "list_documents",
+      arguments: { archive_serial_number__isnull: true, page_size: 100 },
+    })) as ToolResult;
+    assertOk(isnullTrue, "list_documents archive_serial_number__isnull=true");
+    const trueData = parseToolText(isnullTrue) as { results: Array<{ id: number }> };
+    assert.ok(
+      !trueData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} has an ASN and must not appear when archive_serial_number__isnull=true`
+    );
+
+    // ...and included when isnull=false.
+    const isnullFalse = (await client.callTool({
+      name: "list_documents",
+      arguments: { archive_serial_number__isnull: false, page_size: 100 },
+    })) as ToolResult;
+    assertOk(isnullFalse, "list_documents archive_serial_number__isnull=false");
+    const falseData = parseToolText(isnullFalse) as { results: Array<{ id: number }> };
+    assert.ok(
+      falseData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} has an ASN and must appear when archive_serial_number__isnull=false`
+    );
+  });
+
+  it("list_documents filters by custom_fields__icontains", async () => {
+    assert.ok(state.documentId, "document must be uploaded first");
+    const match = (await client.callTool({
+      name: "list_documents",
+      arguments: { custom_fields__icontains: RUN_CUSTOM_FIELD_VALUE },
+    })) as ToolResult;
+    assertOk(match, "list_documents custom_fields__icontains");
+    const matchData = parseToolText(match) as { results: Array<{ id: number }> };
+    assert.ok(
+      matchData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} not found filtering by custom_fields__icontains=${RUN_CUSTOM_FIELD_VALUE}`
+    );
+
+    const miss = (await client.callTool({
+      name: "list_documents",
+      arguments: { custom_fields__icontains: `no-such-${RUN_CUSTOM_FIELD_VALUE}` },
+    })) as ToolResult;
+    assertOk(miss, "list_documents custom_fields__icontains (no match)");
+    const missData = parseToolText(miss) as { results: Array<{ id: number }> };
+    assert.ok(
+      !missData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} should not match a custom_fields__icontains value it does not contain`
+    );
+  });
+
+  it("list_documents filters by custom_field_query", async () => {
+    assert.ok(state.documentId && state.customFieldId, "document and custom field must exist");
+    const query = JSON.stringify([
+      state.customFieldId,
+      "icontains",
+      RUN_CUSTOM_FIELD_VALUE,
+    ]);
+    const result = (await client.callTool({
+      name: "list_documents",
+      arguments: { custom_field_query: query },
+    })) as ToolResult;
+    assertOk(result, "list_documents custom_field_query");
+    const data = parseToolText(result) as { results: Array<{ id: number }> };
+    assert.ok(
+      data.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} not found filtering by custom_field_query=${query}`
+    );
+
+    const missQuery = JSON.stringify([
+      state.customFieldId,
+      "icontains",
+      `no-such-${RUN_CUSTOM_FIELD_VALUE}`,
+    ]);
+    const miss = (await client.callTool({
+      name: "list_documents",
+      arguments: { custom_field_query: missQuery },
+    })) as ToolResult;
+    assertOk(miss, "list_documents custom_field_query (no match)");
+    const missData = parseToolText(miss) as { results: Array<{ id: number }> };
+    assert.ok(
+      !missData.results.some((d) => d.id === state.documentId),
+      `document id=${state.documentId} should not match custom_field_query=${missQuery}`
     );
   });
 });

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -270,14 +270,10 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       if (args.created__date__gte) query.set("created__date__gte", args.created__date__gte);
       if (args.created__date__lte) query.set("created__date__lte", args.created__date__lte);
       if (args.ordering) query.set("ordering", args.ordering);
-      if (args.archive_serial_number !== undefined)
-        query.set("archive_serial_number", args.archive_serial_number.toString());
-      if (args.archive_serial_number__isnull !== undefined)
-        query.set("archive_serial_number__isnull", args.archive_serial_number__isnull.toString());
-      if (args.custom_field_query)
-        query.set("custom_field_query", args.custom_field_query);
-      if (args.custom_fields__icontains)
-        query.set("custom_fields__icontains", args.custom_fields__icontains);
+      if (args.archive_serial_number !== undefined) query.set("archive_serial_number", args.archive_serial_number.toString());
+      if (args.archive_serial_number__isnull !== undefined) query.set("archive_serial_number__isnull", args.archive_serial_number__isnull.toString());
+      if (args.custom_field_query) query.set("custom_field_query", args.custom_field_query);
+      if (args.custom_fields__icontains) query.set("custom_fields__icontains", args.custom_fields__icontains);
 
       const docsResponse = await api.getDocuments(
         query.toString() ? `?${query.toString()}` : ""

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -377,7 +377,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
   server.tool(
     "list_documents",
-    "List and filter documents by fields such as title, correspondent, document type, tag, storage path, creation date, archive serial number, custom fields, and more. IMPORTANT: For queries like 'the last 3 contributions' or when searching by tag, correspondent, document type, or storage path, you should FIRST use the relevant tool (e.g., 'list_tags', 'list_correspondents', 'list_document_types', 'list_storage_paths') to find the correct ID, and then use that ID as a filter here. Only use the 'search' argument for free-text search when no specific field applies. Using the correct ID filter will yield much more accurate results. Note: Document content is excluded from results by default. Use 'get_document_content' to retrieve content when needed.",
+    "List and filter documents by fields such as title, correspondent, document type, tag, storage path, creation date, archive serial number, custom fields, and more. IMPORTANT: For queries like 'the last 3 contributions' or when searching by tag, correspondent, document type, or storage path, you should FIRST use the relevant tool (e.g., 'list_tags', 'list_correspondents', 'list_document_types', 'list_storage_paths') to find the correct ID, and then use that ID as a filter here. Only use the 'search' argument for free-text search when no specific field applies. For custom fields, use 'custom_fields__icontains' for a case-insensitive substring match across custom field values, or 'custom_field_query' for a JSON-encoded query expression (e.g. '[field_id, \"icontains\", \"value\"]'). Using the correct ID filter will yield much more accurate results. Note: Document content is excluded from results by default. Use 'get_document_content' to retrieve content when needed.",
     {
       page: z.number().optional(),
       page_size: z.number().optional(),
@@ -391,8 +391,8 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       ordering: z.string().optional(),
       archive_serial_number: z.number().optional(),
       archive_serial_number__isnull: z.boolean().optional(),
-      custom_field_query: z.string().optional(),
-      custom_fields__icontains: z.string().optional(),
+      custom_field_query: z.string().min(1).optional(),
+      custom_fields__icontains: z.string().min(1).optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -237,7 +237,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
   server.tool(
     "list_documents",
-    "List and filter documents by fields such as title, correspondent, document type, tag, storage path, creation date, and more. IMPORTANT: For queries like 'the last 3 contributions' or when searching by tag, correspondent, document type, or storage path, you should FIRST use the relevant tool (e.g., 'list_tags', 'list_correspondents', 'list_document_types', 'list_storage_paths') to find the correct ID, and then use that ID as a filter here. Only use the 'search' argument for free-text search when no specific field applies. Using the correct ID filter will yield much more accurate results. Note: Document content is excluded from results by default. Use 'get_document_content' to retrieve content when needed.",
+    "List and filter documents by fields such as title, correspondent, document type, tag, storage path, creation date, archive serial number, custom fields, and more. IMPORTANT: For queries like 'the last 3 contributions' or when searching by tag, correspondent, document type, or storage path, you should FIRST use the relevant tool (e.g., 'list_tags', 'list_correspondents', 'list_document_types', 'list_storage_paths') to find the correct ID, and then use that ID as a filter here. Only use the 'search' argument for free-text search when no specific field applies. Using the correct ID filter will yield much more accurate results. Note: Document content is excluded from results by default. Use 'get_document_content' to retrieve content when needed.",
     {
       page: z.number().optional(),
       page_size: z.number().optional(),
@@ -249,6 +249,10 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       created__date__gte: z.string().optional(),
       created__date__lte: z.string().optional(),
       ordering: z.string().optional(),
+      archive_serial_number: z.number().optional(),
+      archive_serial_number__isnull: z.boolean().optional(),
+      custom_field_query: z.string().optional(),
+      custom_fields__icontains: z.string().optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -266,6 +270,14 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       if (args.created__date__gte) query.set("created__date__gte", args.created__date__gte);
       if (args.created__date__lte) query.set("created__date__lte", args.created__date__lte);
       if (args.ordering) query.set("ordering", args.ordering);
+      if (args.archive_serial_number !== undefined)
+        query.set("archive_serial_number", args.archive_serial_number.toString());
+      if (args.archive_serial_number__isnull !== undefined)
+        query.set("archive_serial_number__isnull", args.archive_serial_number__isnull.toString());
+      if (args.custom_field_query)
+        query.set("custom_field_query", args.custom_field_query);
+      if (args.custom_fields__icontains)
+        query.set("custom_fields__icontains", args.custom_fields__icontains);
 
       const docsResponse = await api.getDocuments(
         query.toString() ? `?${query.toString()}` : ""


### PR DESCRIPTION
- Added archive_serial_number filter parameter
- Added archive_serial_number__isnull filter parameter
- Added custom_field_query filter parameter
- Added custom_fields__icontains filter parameter

These filters enable searching documents by:
- Specific archive serial numbers (ASN)
- Documents with/without ASN
- Custom field values (full-text search)
- Custom field content matching

All parameters are optional and follow Paperless-NGX API conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document filters for archive serial number, ability to filter for missing/NULL serials, and richer custom-field queries including substring matching.

* **Documentation**
  * Clarified when to use ID-based filters versus free-text search to improve query accuracy and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->