### PR TITLE
feat: add MCP tool annotations (readOnly/destructive hints)

### DIFF
--- a/.changeset/mcp-tool-annotations.md
+++ b/.changeset/mcp-tool-annotations.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+Add MCP tool annotations (readOnlyHint/destructiveHint/openWorldHint) to all tools, derived from the tool-name verb prefix, so MCP clients can distinguish reads from destructive writes.

--- a/.changeset/mcp-tool-annotations.md
+++ b/.changeset/mcp-tool-annotations.md
@@ -2,4 +2,4 @@
 "@baruchiro/paperless-mcp": minor
 ---
 
-Add MCP tool annotations (readOnlyHint/destructiveHint/openWorldHint) to all tools, derived from the tool-name verb prefix, so MCP clients can distinguish reads from destructive writes.
+Add MCP tool annotations (readOnlyHint/destructiveHint/openWorldHint) to every tool. Each tool declares its annotations explicitly at its registration call site (read-only, write, or destructive), and a test enforces that every registered tool has annotations. This lets MCP clients distinguish read-only tools from writes and flag destructive operations.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
-import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type express from "express";
 import { PaperlessAPI } from "./api/PaperlessAPI";
 import { registerDocumentResources } from "./resources/documents";
@@ -17,22 +16,6 @@ export interface CreateMcpServerOptions {
   publicUrl: string;
 }
 
-/**
- * Derive MCP tool annotations from the tool-name verb prefix so clients can
- * distinguish reads from writes and flag destructive calls: list_/get_/search_/
- * download_ are read-only, delete_/bulk_edit_ are destructive, everything else
- * is a non-destructive write. Paperless-ngx is a closed system, so
- * openWorldHint is false.
- */
-function toolAnnotations(name: string): ToolAnnotations {
-  const n = name.toLowerCase();
-  if (/^(list_|get_|search_|download_)/.test(n)) {
-    return { readOnlyHint: true, openWorldHint: false };
-  }
-  const destructive = /^(delete_|bulk_edit_)/.test(n);
-  return { readOnlyHint: false, destructiveHint: destructive, openWorldHint: false };
-}
-
 export function createMcpServer({
   baseUrl,
   token,
@@ -44,18 +27,6 @@ export function createMcpServer({
     { name: "paperless-ngx", version },
     { instructions: buildInstructions(publicUrl) }
   );
-
-  // The SDK leaves tool annotations unset unless passed explicitly. Wrap
-  // server.tool so every tool the register*Tools helpers register gets its
-  // annotations stamped by verb prefix — no change needed at each call site.
-  const registerBaseTool = server.tool.bind(server) as (...args: unknown[]) => RegisteredTool;
-  server.tool = ((name: string, ...rest: unknown[]): RegisteredTool => {
-    const registered = registerBaseTool(name, ...rest);
-    if (!registered.annotations) {
-      registered.update({ annotations: toolAnnotations(name) });
-    }
-    return registered;
-  }) as typeof server.tool;
 
   registerDocumentTools(server, api);
   registerDocumentResources(server, api);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type express from "express";
 import { PaperlessAPI } from "./api/PaperlessAPI";
 import { registerDocumentResources } from "./resources/documents";
@@ -16,6 +17,22 @@ export interface CreateMcpServerOptions {
   publicUrl: string;
 }
 
+/**
+ * Derive MCP tool annotations from the tool-name verb prefix so clients can
+ * distinguish reads from writes and flag destructive calls: list_/get_/search_/
+ * download_ are read-only, delete_/bulk_edit_ are destructive, everything else
+ * is a non-destructive write. Paperless-ngx is a closed system, so
+ * openWorldHint is false.
+ */
+function toolAnnotations(name: string): ToolAnnotations {
+  const n = name.toLowerCase();
+  if (/^(list_|get_|search_|download_)/.test(n)) {
+    return { readOnlyHint: true, openWorldHint: false };
+  }
+  const destructive = /^(delete_|bulk_edit_)/.test(n);
+  return { readOnlyHint: false, destructiveHint: destructive, openWorldHint: false };
+}
+
 export function createMcpServer({
   baseUrl,
   token,
@@ -27,6 +44,19 @@ export function createMcpServer({
     { name: "paperless-ngx", version },
     { instructions: buildInstructions(publicUrl) }
   );
+
+  // The SDK leaves tool annotations unset unless passed explicitly. Wrap
+  // server.tool so every tool the register*Tools helpers register gets its
+  // annotations stamped by verb prefix — no change needed at each call site.
+  const registerBaseTool = server.tool.bind(server) as (...args: unknown[]) => RegisteredTool;
+  server.tool = ((name: string, ...rest: unknown[]): RegisteredTool => {
+    const registered = registerBaseTool(name, ...rest);
+    if (!registered.annotations) {
+      registered.update({ annotations: toolAnnotations(name) });
+    }
+    return registered;
+  }) as typeof server.tool;
+
   registerDocumentTools(server, api);
   registerDocumentResources(server, api);
   registerTagTools(server, api);

--- a/src/tools/annotations.test.ts
+++ b/src/tools/annotations.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createMcpServer } from "../server";
+
+// Enforce that every registered MCP tool declares annotations. If this fails,
+// a tool was added without an annotation argument at its server.tool(...) call.
+test("every registered tool declares MCP annotations", () => {
+  const server = createMcpServer({
+    baseUrl: "http://localhost",
+    token: "test-token",
+    version: "0.0.0-test",
+    publicUrl: "http://localhost",
+  });
+
+  const registered = (server as unknown as {
+    _registeredTools: Record<string, { annotations?: Record<string, unknown> }>;
+  })._registeredTools;
+
+  const names = Object.keys(registered);
+  assert.ok(names.length > 0, "expected at least one registered tool");
+
+  for (const [name, tool] of Object.entries(registered)) {
+    const annotations = tool.annotations;
+    assert.ok(annotations, `tool "${name}" is missing annotations`);
+    assert.equal(
+      typeof annotations.readOnlyHint,
+      "boolean",
+      `tool "${name}" is missing a readOnlyHint`
+    );
+    assert.equal(
+      typeof annotations.openWorldHint,
+      "boolean",
+      `tool "${name}" is missing an openWorldHint`
+    );
+    if (annotations.readOnlyHint === false) {
+      assert.equal(
+        typeof annotations.destructiveHint,
+        "boolean",
+        `writable tool "${name}" is missing a destructiveHint`
+      );
+    }
+  }
+});

--- a/src/tools/annotations.test.ts
+++ b/src/tools/annotations.test.ts
@@ -26,9 +26,9 @@ test("every registered tool declares MCP annotations", () => {
       `tool "${name}" is missing a readOnlyHint`
     );
     assert.equal(
-      typeof annotations.openWorldHint,
-      "boolean",
-      `tool "${name}" is missing an openWorldHint`
+      annotations.openWorldHint,
+      false,
+      `tool "${name}" must set openWorldHint to false`
     );
     if (annotations.readOnlyHint === false) {
       assert.equal(

--- a/src/tools/annotations.test.ts
+++ b/src/tools/annotations.test.ts
@@ -2,8 +2,6 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { createMcpServer } from "../server";
 
-// Enforce that every registered MCP tool declares annotations. If this fails,
-// a tool was added without an annotation argument at its server.tool(...) call.
 test("every registered tool declares MCP annotations", () => {
   const server = createMcpServer({
     baseUrl: "http://localhost",

--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -6,6 +6,7 @@ import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -25,6 +26,7 @@ export function registerCorrespondentTools(
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -50,6 +52,7 @@ export function registerCorrespondentTools(
     "get_correspondent",
     "Get a specific correspondent by ID with full details including matching rules.",
     { id: z.number() },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.getCorrespondent(args.id);
@@ -76,6 +79,7 @@ export function registerCorrespondentTools(
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.createCorrespondent(args);
@@ -103,6 +107,7 @@ export function registerCorrespondentTools(
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { id, ...data } = args;
@@ -125,6 +130,7 @@ export function registerCorrespondentTools(
         .boolean()
         .describe("Must be true to confirm this destructive operation"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (!args.confirm) {
@@ -168,6 +174,7 @@ export function registerCorrespondentTools(
         .optional(),
       merge: z.boolean().optional(),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (args.operation === "delete" && !args.confirm) {

--- a/src/tools/customFields.ts
+++ b/src/tools/customFields.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 import { PaperlessAPI } from "../api/PaperlessAPI";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -17,6 +18,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args = {}) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -38,6 +40,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
     "get_custom_field",
     "Get a specific custom field by ID with full details including data type and extra configuration.",
     { id: z.number() },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.getCustomField(args.id);
@@ -65,6 +68,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
       ]),
       extra_data: z.record(z.unknown()).nullable().optional(),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.createCustomField(args);
@@ -95,6 +99,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
         .optional(),
       extra_data: z.record(z.unknown()).nullable().optional(),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { id, ...data } = args;
@@ -112,6 +117,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
       id: z.number(),
       confirm: z.boolean().describe("Must be true to confirm this destructive operation"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (!args.confirm) {
@@ -134,6 +140,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
       operation: z.enum(["delete"]),
       confirm: z.boolean().optional().describe("Must be true when operation is 'delete' to confirm destructive operation"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (args.operation === "delete" && !args.confirm) {

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -6,6 +6,7 @@ import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -25,6 +26,7 @@ export function registerDocumentTypeTools(
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args = {}, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -52,6 +54,7 @@ export function registerDocumentTypeTools(
     "get_document_type",
     "Get a specific document type by ID with full details including matching rules.",
     { id: z.number() },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.request(`/document_types/${args.id}/`);
@@ -76,6 +79,7 @@ export function registerDocumentTypeTools(
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.createDocumentType(args);
@@ -101,6 +105,7 @@ export function registerDocumentTypeTools(
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { id, ...payloadWithoutId } = args;
@@ -121,6 +126,7 @@ export function registerDocumentTypeTools(
         .boolean()
         .describe("Must be true to confirm this destructive operation"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (!args.confirm) {
@@ -164,6 +170,7 @@ export function registerDocumentTypeTools(
         .optional(),
       merge: z.boolean().optional(),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (args.operation === "delete" && !args.confirm) {

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -5,6 +5,7 @@ import { constants } from "fs";
 import { basename, isAbsolute } from "path";
 import { convertDocsWithNames } from "../api/documentEnhancer";
 import { PaperlessAPI } from "../api/PaperlessAPI";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { arrayNotEmpty, objectNotEmpty } from "./utils/empty";
 import { withErrorHandling } from "./utils/middlewares";
 import { validateCustomFields } from "./utils/monetary";
@@ -207,6 +208,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           "Must be true when method is 'delete' to confirm destructive operation"
         ),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (args.method === "delete" && !args.confirm) {
@@ -306,6 +308,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     "post_document",
     "Upload a new document to Paperless-NGX with optional metadata like title, correspondent, document type, tags, and custom fields. Provide either 'file' (base64-encoded content) or 'file_path' (absolute path to a file on the server's filesystem). Using file_path avoids base64 encoding overhead for large files. SECURITY: When using file_path, set PAPERLESS_MCP_UPLOAD_PATHS environment variable to restrict uploads to specific directories (colon-separated paths).",
     postDocumentBaseSchema.shape,
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
 
@@ -394,6 +397,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       custom_field_query: z.string().min(1).optional(),
       custom_fields__icontains: z.string().min(1).optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const query = new URLSearchParams();
@@ -428,6 +432,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     {
       id: z.number(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const doc = await api.getDocument(args.id);
@@ -441,6 +446,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     {
       id: z.number(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const doc = await api.getDocument(args.id);
@@ -465,6 +471,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     {
       query: z.string(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const docsResponse = await api.searchDocuments(args.query);
@@ -479,6 +486,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       id: z.number().int().positive(),
       original: z.boolean().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const uri = buildDocumentResourceUri(args.id, {
@@ -508,6 +516,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     {
       id: z.number().int().positive(),
     },
+    READ_ONLY,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       return {
@@ -591,6 +600,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
         .optional()
         .describe("Array of custom field values to assign"),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { id, ...updateData } = args;

--- a/src/tools/mail.ts
+++ b/src/tools/mail.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 import { PaperlessAPI } from "../api/PaperlessAPI";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -88,6 +89,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       page: z.number().optional(),
       page_size: z.number().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args = {}) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -111,6 +113,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
     "get_mail_account",
     "Get one Paperless mail account by ID. Password/token fields are redacted if the server returns them.",
     { id: z.number().int() },
+    READ_ONLY,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const { password, ...account } = await api.getMailAccount(args.id);
@@ -124,6 +127,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
     "process_mail_account",
     "Manually run Paperless mail processing for one account. This can consume matching mails according to enabled Paperless mail rules.",
     { id: z.number().int() },
+    WRITE,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       await api.processMailAccount(args.id);
@@ -142,6 +146,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       page: z.number().optional(),
       page_size: z.number().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args = {}) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -156,6 +161,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
     "get_mail_rule",
     "Get one Paperless mail rule by ID.",
     { id: z.number().int() },
+    READ_ONLY,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.getMailRule(args.id);
@@ -174,6 +180,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       account: z.number().int(),
       folder: z.string(),
     },
+    WRITE,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.createMailRule(args);
@@ -190,6 +197,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       id: z.number().int(),
       ...mailRuleFields,
     },
+    WRITE,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const { id, ...data } = args;
@@ -209,6 +217,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
         .boolean()
         .describe("Must be true to confirm deleting the rule"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       if (!args.confirm) {

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -6,6 +6,7 @@ import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { READ_ONLY, WRITE, DESTRUCTIVE } from "./utils/annotations";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -22,6 +23,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
+    READ_ONLY,
     withErrorHandling(async (args = {}) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
@@ -63,6 +65,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const tag = await api.createTag(args);
@@ -97,6 +100,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .optional()
         .describe(MATCHING_ALGORITHM_DESCRIPTION),
     },
+    WRITE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const tag = await api.updateTag(args.id, args);
@@ -121,6 +125,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .boolean()
         .describe("Must be true to confirm this destructive operation"),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (!args.confirm) {
@@ -167,6 +172,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .optional(),
       merge: z.boolean().optional(),
     },
+    DESTRUCTIVE,
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       if (args.operation === "delete" && !args.confirm) {

--- a/src/tools/utils/annotations.ts
+++ b/src/tools/utils/annotations.ts
@@ -3,20 +3,17 @@ import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 // Paperless-ngx is a closed system, so openWorldHint is always false. These three
 // constants cover every tool; pass a custom object for a per-tool exception.
 
-/** Read-only tool: no side effects. */
 export const READ_ONLY: ToolAnnotations = {
   readOnlyHint: true,
   openWorldHint: false,
 };
 
-/** Write tool that creates or updates but never deletes. */
 export const WRITE: ToolAnnotations = {
   readOnlyHint: false,
   destructiveHint: false,
   openWorldHint: false,
 };
 
-/** Write tool that can permanently delete data from the system. */
 export const DESTRUCTIVE: ToolAnnotations = {
   readOnlyHint: false,
   destructiveHint: true,

--- a/src/tools/utils/annotations.ts
+++ b/src/tools/utils/annotations.ts
@@ -1,0 +1,24 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+// Paperless-ngx is a closed system, so openWorldHint is always false. These three
+// constants cover every tool; pass a custom object for a per-tool exception.
+
+/** Read-only tool: no side effects. */
+export const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: false,
+};
+
+/** Write tool that creates or updates but never deletes. */
+export const WRITE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+};
+
+/** Write tool that can permanently delete data from the system. */
+export const DESTRUCTIVE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: false,
+};


### PR DESCRIPTION
## What

Stamps MCP tool `annotations` (`readOnlyHint` / `destructiveHint` / `openWorldHint`) onto every registered tool, derived from the tool-name verb prefix:

- `list_` / `get_` / `search_` / `download_` → `readOnlyHint: true`
- `delete_` / `bulk_edit_` → `destructiveHint: true`
- everything else → non-destructive write
- `openWorldHint: false` (Paperless-ngx is a closed system)

It is implemented as a one-time wrap of `server.tool` in `createMcpServer` (using the public `RegisteredTool.update()`), so no change is needed at any `server.tool(...)` call site and new tools are covered automatically. It only fills in annotations a tool has not already set, so explicit per-tool annotations would still win.

## Why

MCP tool annotations are the hints clients use to present and guard tools — flagging or confirming destructive operations. The server already encodes this intent in prose (`⚠️ DESTRUCTIVE: ...`); this exposes it as the structured field clients actually read. Without it a client cannot tell `get_document` from `delete_document`.

## Notes

No change to tool behavior — only `tools/list` gains `annotations`. The verb prefixes follow the existing tool naming convention. If you would prefer explicit per-tool annotations instead of the wrapper, happy to expand it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MCP tool annotations across the server to label each operation as **read-only**, **write**, or **destructive**, helping MCP clients better understand tool intent and safety.
* **Tests**
  * Added an automated check to ensure every registered tool includes the required annotation hints and expected boolean values.
* **Chores**
  * Updated release metadata for a **minor** version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->