### PR TITLE
Fix e2e test flakiness by using PostgreSQL instead of SQLite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,12 +23,32 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
+      # Paperless defaults to SQLite, which serializes writes and intermittently
+      # raises "database is locked" when the consumer and a bulk-edit task write
+      # concurrently. Back it with PostgreSQL to match production and remove the
+      # flake.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: paperless
+          POSTGRES_USER: paperless
+          POSTGRES_PASSWORD: paperless
+        options: >-
+          --health-cmd "pg_isready -U paperless"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
       paperless:
         # Track upstream stable. Paperless-ngx publishes the latest stable
         # release under :latest; the weekly schedule catches drift.
         image: ghcr.io/paperless-ngx/paperless-ngx:latest
         env:
           PAPERLESS_REDIS: redis://redis:6379
+          PAPERLESS_DBHOST: postgres
+          PAPERLESS_DBNAME: paperless
+          PAPERLESS_DBUSER: paperless
+          PAPERLESS_DBPASS: paperless
           PAPERLESS_ADMIN_USER: admin
           PAPERLESS_ADMIN_PASSWORD: admin123
           PAPERLESS_ADMIN_MAIL: admin@test.local


### PR DESCRIPTION
## Summary
Replaces SQLite with PostgreSQL in the e2e test environment to eliminate intermittent "database is locked" errors that occur when the consumer and bulk-edit tasks write concurrently.

## Changes
- Added PostgreSQL 16 Alpine service to the e2e workflow with health checks
- Configured Paperless-NGX to use PostgreSQL instead of the default SQLite:
  - `PAPERLESS_DBHOST: postgres`
  - `PAPERLESS_DBNAME: paperless`
  - `PAPERLESS_DBUSER: paperless`
  - `PAPERLESS_DBPASS: paperless`

## Details
SQLite serializes writes and raises "database is locked" errors under concurrent load. PostgreSQL matches the production environment and eliminates this flakiness. The PostgreSQL service includes health checks to ensure it's ready before tests run.

https://claude.ai/code/session_01XYCjssJimDZox1VeVAH5nu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end testing now runs with PostgreSQL as the application database.
  * Added database health checks and configuration to improve test environment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->