### PR TITLE
docs: clarify update_document custom_fields replace semantics

### DIFF
--- a/.changeset/clarify-update-document-custom-fields.md
+++ b/.changeset/clarify-update-document-custom-fields.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Clarify update_document's custom_fields behavior: the array replaces the document's entire custom-field set (omitted fields are cleared). Updated the tool and parameter descriptions to warn about this and describe how to do a partial update.

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -520,7 +520,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
   server.tool(
     "update_document",
-    "Update a specific document with new values. This tool allows you to modify any document field including title, correspondent, document type, storage path, tags, custom fields, and more. Only the fields you specify will be updated.",
+    "Update a specific document with new values (title, correspondent, document type, storage path, tags, custom fields, and more). Top-level fields you omit are left unchanged. IMPORTANT: custom_fields is the exception — see its parameter description; it replaces the document's entire custom-field set.",
     {
       id: z.number().describe("The ID of the document to update"),
       title: z
@@ -580,7 +580,9 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           })
         )
         .optional()
-        .describe("Array of custom field values to assign"),
+        .describe(
+          "Custom field values for the document. ⚠️ REPLACES the document's entire custom-field set — any field not included here will be CLEARED. To update or add a single field without losing the others, first call get_document to read the existing custom_fields, then pass the full merged array. To add/set fields additively without fetching, use bulk_edit_documents with method 'modify_custom_fields' instead."
+        ),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");


### PR DESCRIPTION
The custom_fields array in update_document is sent verbatim in the
PATCH request, so Paperless replaces the document's entire custom-field
set — any omitted field is cleared. The tool and parameter descriptions
previously implied partial-update semantics ("Only the fields you
specify will be updated"), which led callers to unintentionally delete
fields (fix #127).

Update both descriptions to warn about the replace behavior and explain
how to do a partial update (fetch-then-resend, or bulk_edit_documents
with modify_custom_fields). No behavior change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014BL2ca8xu7CG1e1PdEagDS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `update_document.custom_fields` replaces the document’s entire custom-field set.
  * Added an explicit warning that any omitted custom-field entries are cleared.
  * Documented recommended approaches for partial custom-field updates that preserve existing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->