### PR TITLE
fix(api): bump default Paperless API version to 9 (fixes #129)

### DIFF
--- a/.changeset/default-api-version-9.md
+++ b/.changeset/default-api-version-9.md
@@ -2,4 +2,8 @@
 "@baruchiro/paperless-mcp": patch
 ---
 
-Bump the default Paperless-ngx REST API version from `5` to `9`. Paperless-ngx v3.0.0 dropped support for API versions below `9` and returns HTTP 406 for them, which broke every request under the previous default. Version `9` is supported on both recent Paperless-ngx v2.x and v3.x, giving the widest compatibility; it remains overridable via `PAPERLESS_API_VERSION`. The e2e workflow now runs against both a 2.x and the latest 3.x Paperless image to guard against version-compatibility regressions.
+Bump the default Paperless-ngx REST API version from `5` to `9`. Paperless-ngx v3.0.0 dropped support for API versions below `9` and returns HTTP 406 for them, which broke every request under the previous default. Version `9` is supported on both recent Paperless-ngx v2.x and v3.x, giving the widest compatibility; it remains overridable via `PAPERLESS_API_VERSION`.
+
+`update_document` now sends select custom-field values in Paperless's stored form (the option id for 2.17+ fields, the index for legacy string-option fields) to match the v9+ document endpoint, which rejects the bare option index — bringing it in line with `bulk_edit_documents`.
+
+The e2e workflow now runs against both a 2.x and the latest 3.x Paperless image to guard against version-compatibility regressions.

--- a/.changeset/default-api-version-9.md
+++ b/.changeset/default-api-version-9.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Bump the default Paperless-ngx REST API version from `5` to `9`. Paperless-ngx v3.0.0 dropped support for API versions below `9` and returns HTTP 406 for them, which broke every request under the previous default. Version `9` is supported on both recent Paperless-ngx v2.x and v3.x, giving the widest compatibility; it remains overridable via `PAPERLESS_API_VERSION`. The e2e workflow now runs against both a 2.x and the latest 3.x Paperless image to guard against version-compatibility regressions.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,21 @@ on:
 
 jobs:
   e2e:
+    name: e2e (Paperless ${{ matrix.series }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Latest maintained 2.x line. Guards against regressing support for
+          # users still on Paperless-ngx v2.
+          - series: "2.x"
+            paperless_image: ghcr.io/paperless-ngx/paperless-ngx:2.20
+          # Upstream stable (currently v3.x). The weekly schedule catches drift
+          # when a new :latest is published.
+          - series: "3.x (latest)"
+            paperless_image: ghcr.io/paperless-ngx/paperless-ngx:latest
 
     services:
       redis:
@@ -40,9 +54,7 @@ jobs:
           --health-retries 10
 
       paperless:
-        # Track upstream stable. Paperless-ngx publishes the latest stable
-        # release under :latest; the weekly schedule catches drift.
-        image: ghcr.io/paperless-ngx/paperless-ngx:latest
+        image: ${{ matrix.paperless_image }}
         env:
           PAPERLESS_REDIS: redis://redis:6379
           PAPERLESS_DBHOST: postgres

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ The `src/api/PaperlessAPI.ts` class implements all API operations:
 - **Base URL**: Always use `/api` prefix for all endpoints
 - **Authentication**: Include `Authorization: Token ${token}` header
 - **Content-Type**: Use `application/json` for JSON requests
-- **Version**: Include `Accept: application/json; version=5` header
+- **Version**: Include `Accept: application/json; version=9` header (default; overridable via `PAPERLESS_API_VERSION`)
 - **File Uploads**: Use `FormData` for multipart requests
 - Use generic types for all API calls; return typed responses matching defined interfaces
 - Check HTTP status codes and handle errors gracefully

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add these to your MCP config file:
 | `PAPERLESS_URL` | Yes | — | Base URL of your Paperless-NGX instance |
 | `PAPERLESS_API_KEY` | Yes | — | API token from your Paperless-NGX profile |
 | `PAPERLESS_PUBLIC_URL` | No | `PAPERLESS_URL` | Public-facing URL for document links |
-| `PAPERLESS_API_VERSION` | No | `5` | Paperless-ngx REST API version. Use `10` for Paperless-ngx v3+. If you see HTTP 406 errors, set this to `10`. |
+| `PAPERLESS_API_VERSION` | No | `9` | Paperless-ngx REST API version. `9` works on Paperless-ngx v2.x (recent) and v3.x. Paperless-ngx v3.0.0 dropped support for versions below `9`, so older defaults now return HTTP 406. If you see HTTP 406 errors, set this to a version your server supports. |
 | `PAPERLESS_MCP_UPLOAD_PATHS` | No | — | Colon-separated list of allowed directories for `file_path` uploads. **Recommended for security.** Example: `/var/uploads:/tmp/scans` |
 
 That's it! Now you can ask Claude to help you manage your Paperless-NGX documents.

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -730,11 +730,14 @@ describe("Paperless MCP E2E scenario", () => {
     const options = field.extra_data?.select_options ?? [];
     const labelOf = (opt: string | { label?: string } | undefined) =>
       typeof opt === "string" ? opt : opt?.label;
+    const idOf = (opt: string | { id?: string } | undefined) =>
+      typeof opt === "string" ? undefined : opt?.id;
     state.selectOptionLabel = labelOf(options[0]);
-    // get_document returns the option's zero-based index at API version 5.
-    state.selectOptionValue = 0;
+    // Paperless API v9+ stores and returns the select option's id (e.g. "keep"),
+    // not the zero-based index that API v5 used.
+    state.selectOptionValue = idOf(options[0]);
     assert.ok(
-      state.selectOptionLabel && options.length >= 2,
+      state.selectOptionLabel && state.selectOptionValue && options.length >= 2,
       `expected the created select options, got ${JSON.stringify(options)}`
     );
   });

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -16,9 +16,11 @@ const RUN_DOCUMENT_TITLE = `E2E Document ${Date.now()}`;
 const RUN_SELECT_FIELD = `E2E Select ${Date.now()}`;
 const RUN_CUSTOM_FIELD = `e2e_cf_${Date.now()}`;
 const RUN_CUSTOM_FIELD_VALUE = `cf-value-${Date.now()}`;
-// archive_serial_number is a unique uint32 in Paperless; derive an in-range
-// value from the run timestamp so the CLI and Docker passes use distinct ASNs.
-const RUN_ASN = Date.now() % 4294967295;
+// archive_serial_number is a Paperless PositiveIntegerField, stored as a signed
+// 32-bit PostgreSQL integer (max 2147483647). Derive an in-range value from the
+// run timestamp so the CLI and Docker passes use distinct ASNs; modulo by the
+// int4 max keeps it from overflowing the column.
+const RUN_ASN = Date.now() % 2147483647;
 
 // Paperless rejects duplicate uploads by checksum. When the same suite runs
 // twice against one Paperless instance (e.g. CLI then Docker in one CI job),

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -30,7 +30,7 @@ export class PaperlessAPI {
   ) {
     this.baseUrl = baseUrl;
     this.token = token;
-    this.apiVersion = process.env.PAPERLESS_API_VERSION || "5";
+    this.apiVersion = process.env.PAPERLESS_API_VERSION || "9";
   }
 
   async request<T = any>(path: string, options: RequestInit = {}) {
@@ -75,7 +75,7 @@ export class PaperlessAPI {
       if (axios.isAxiosError(error) && error.response?.status === 406) {
         throw new Error(
           `HTTP 406: Paperless-ngx rejected API version ${this.apiVersion}. ` +
-            `Set the PAPERLESS_API_VERSION environment variable to match your server's API version (e.g., "10" for Paperless-ngx v3+).`
+            `Set the PAPERLESS_API_VERSION environment variable to a version your server supports (e.g., "9" or "10" for Paperless-ngx v3+, or a lower value for older servers).`
         );
       }
       console.error({
@@ -162,7 +162,7 @@ export class PaperlessAPI {
       if (axios.isAxiosError(error) && error.response?.status === 406) {
         throw new Error(
           `HTTP 406: Paperless-ngx rejected API version ${this.apiVersion}. ` +
-            `Set the PAPERLESS_API_VERSION environment variable to match your server's API version (e.g., "10" for Paperless-ngx v3+).`
+            `Set the PAPERLESS_API_VERSION environment variable to a version your server supports (e.g., "9" or "10" for Paperless-ngx v3+, or a lower value for older servers).`
         );
       }
       throw error;

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -543,7 +543,7 @@ describe("select custom field value resolution in document handlers", () => {
     assert.deepEqual(data.custom_fields, [{ field: 2, value: 0 }]);
   });
 
-  test("update_document translates a select label to its option index (Paperless 2.17+)", async () => {
+  test("update_document sends the option id for 2.17+ select fields (stored form)", async () => {
     const { api, calls } = createDocumentApi([OBJECT_SELECT_FIELD]);
 
     await withDocumentClient(api, async (client) => {
@@ -555,7 +555,7 @@ describe("select custom field value resolution in document handlers", () => {
     });
 
     const [, data] = calls.updateDocument[0];
-    assert.deepEqual(data.custom_fields, [{ field: 3, value: 1 }]);
+    assert.deepEqual(data.custom_fields, [{ field: 3, value: "def456" }]);
   });
 
   test("bulk_edit_documents translates a select label in add_custom_fields", async () => {

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -590,7 +590,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       updateData.custom_fields = await resolveSelectCustomFieldValues(
         api,
         updateData.custom_fields,
-        "index"
+        "stored"
       );
 
       const response = await api.updateDocument(id, updateData);

--- a/src/tools/utils/selectFields.ts
+++ b/src/tools/utils/selectFields.ts
@@ -6,9 +6,11 @@ import {
 } from "../../api/types";
 
 /**
- * Encoding Paperless expects for a select value: `update_document` takes the
- * option index; `bulk_edit` writes `value_select` directly so it needs the
- * stored form (option id on 2.17+, index on pre-2.17 string options).
+ * Encoding Paperless expects for a select value. On the supported API versions
+ * (v9+) both `update_document` and `bulk_edit` take the option's stored form:
+ * the option id on 2.17+ fields, or the index on pre-2.17 string-option fields.
+ * The bare `index` form is retained for older API versions whose document
+ * endpoint accepted the option index directly.
  */
 export type SelectValueEncoding = "index" | "stored";
 


### PR DESCRIPTION
Paperless-ngx v3.0.0 dropped support for REST API versions below 9 and
now returns HTTP 406 for the previous default (version 5), breaking every
request against v3+ servers. Version 9 is supported on both recent
Paperless-ngx 2.x and 3.x, so it is the widest-compatibility default; it
stays overridable via PAPERLESS_API_VERSION.

Also run the e2e workflow as a matrix against a 2.x and the latest 3.x
Paperless image to catch version-compatibility regressions, and refresh
the 406 hint message and docs to match the new default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0124FXugGgXggWY8jWAmnfcj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Paperless-ngx REST API version to **9** for better compatibility with Paperless-ngx **v2.x** and **v3.x**.
  * Refreshed the messaging when an unsupported API version is rejected (HTTP **406**), including guidance to use `PAPERLESS_API_VERSION`.

* **Documentation**
  * Updated `PAPERLESS_API_VERSION` defaults and compatibility notes in the README and CLAUDE documentation.

* **Tests**
  * Expanded E2E coverage to run against both Paperless-ngx **2.x** and **latest 3.x**.
  * Adjusted E2E archive serial-number generation for improved test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->