### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.changeset/upgrade-actions-node24.md
+++ b/.changeset/upgrade-actions-node24.md
@@ -2,4 +2,4 @@
 "@baruchiro/paperless-mcp": patch
 ---
 
-Upgrade GitHub Actions to versions running on Node.js 24, resolving the Node.js 20 deprecation warnings on the runners. Bumped actions/checkout v4→v5, actions/stale v9→v10, docker/setup-qemu-action v3→v4, docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/metadata-action v5→v6, and docker/build-push-action v6→v7.
+Upgrade GitHub Actions to versions running on Node.js 24, resolving the Node.js 20 deprecation warnings on the runners. Bumped actions/checkout v4→v5, actions/stale v9→v10, docker/setup-qemu-action v3→v4, docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/metadata-action v5→v6, and docker/build-push-action v6→v7. Also set `persist-credentials: false` on checkout in the ci, e2e, and docker-publish workflows, which don't run authenticated git operations (the release workflow keeps credentials for its Changesets push).

--- a/.changeset/upgrade-actions-node24.md
+++ b/.changeset/upgrade-actions-node24.md
@@ -1,5 +1,0 @@
----
-"@baruchiro/paperless-mcp": patch
----
-
-Upgrade GitHub Actions to versions running on Node.js 24, resolving the Node.js 20 deprecation warnings on the runners. Bumped actions/checkout v4→v5, actions/stale v9→v10, docker/setup-qemu-action v3→v4, docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/metadata-action v5→v6, and docker/build-push-action v6→v7. Also set `persist-credentials: false` on checkout in the ci, e2e, and docker-publish workflows, which don't run authenticated git operations (the release workflow keeps credentials for its Changesets push).

--- a/.changeset/upgrade-actions-node24.md
+++ b/.changeset/upgrade-actions-node24.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Upgrade GitHub Actions to versions running on Node.js 24, resolving the Node.js 20 deprecation warnings on the runners. Bumped actions/checkout v4→v5, actions/stale v9→v10, docker/setup-qemu-action v3→v4, docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/metadata-action v5→v6, and docker/build-push-action v6→v7.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,11 +17,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Check if PR is from fork
         id: check-fork
         run: |
@@ -36,7 +36,7 @@ jobs:
           fi
       - name: Log in to GitHub Container Registry
         if: steps.check-fork.outputs.is_fork == 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
           fi
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -66,7 +66,7 @@ jobs:
             ${{ steps.tagmeta.outputs.SEMVER }}
             ${{ steps.tagmeta.outputs.LATEST }}
       - name: Build (linux/amd64) for smoke test
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -98,7 +98,7 @@ jobs:
           docker rm -f paperless-mcp-smoke
           exit 1
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,7 @@ jobs:
           --health-start-period 60s
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -92,10 +92,10 @@ jobs:
         run: npm run build
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for E2E
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
       versionTag: ${{ steps.version.outputs.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           ascending: true
           days-before-stale: 60


### PR DESCRIPTION
## Summary
Upgrades all GitHub Actions workflows to versions that run on Node.js 24, resolving deprecation warnings from the Node.js 20 EOL on GitHub runners.

## Changes
- **actions/checkout**: v4 → v5
- **actions/stale**: v9 → v10
- **docker/setup-qemu-action**: v3 → v4
- **docker/setup-buildx-action**: v3 → v4
- **docker/login-action**: v3 → v4
- **docker/metadata-action**: v5 → v6
- **docker/build-push-action**: v6 → v7

## Affected Workflows
- `.github/workflows/ci.yml`
- `.github/workflows/docker-publish.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/release.yml`
- `.github/workflows/stale.yml`

All workflows now use Node.js 24 compatible action versions, eliminating deprecation warnings while maintaining existing functionality.

https://claude.ai/code/session_01VnYjLByMZ3GPBLNBDuYEsr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build, test, end-to-end, release, and container publishing workflows to use newer action versions.
  * Improved checkout credential handling in end-to-end automation.
  * Updated stale-item management automation while preserving its existing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->