### PR TITLE
fix(release): install npm into a separate prefix to avoid self-upgrade failure

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/fix-release-npm-upgrade.md
+++ b/.changeset/fix-release-npm-upgrade.md
@@ -1,9 +1,0 @@
----
-"@baruchiro/paperless-mcp": patch
----
-
-Harden the release workflow:
-
-- Install npm into a separate prefix instead of overwriting the running npm (which could fail mid-reify with "Cannot find module 'promise-retry'"), and pin to a trusted-publishing-compatible version (`npm@^11.5.1`) instead of `@latest`.
-- Publish with `changeset publish` instead of raw `npm publish`, so a push to `main` with no pending changeset is a no-op instead of failing with "cannot publish over the previously published versions". Provenance is preserved via `NPM_CONFIG_PROVENANCE`, and `access` is set to `public` in the changesets config.
-- Only run the `docker-publish` job when a version was actually published: the version-extraction step now emits an empty string (instead of `null`) on a no-op run, and `docker-publish` is gated on a non-empty `versionTag`.

--- a/.changeset/fix-release-npm-upgrade.md
+++ b/.changeset/fix-release-npm-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Fix the release workflow's npm upgrade step: install npm into a separate prefix instead of overwriting the running npm (which could fail mid-reify with "Cannot find module 'promise-retry'"), and pin to a trusted-publishing-compatible version (`npm@^11.5.1`) instead of `@latest`.

--- a/.changeset/fix-release-npm-upgrade.md
+++ b/.changeset/fix-release-npm-upgrade.md
@@ -2,4 +2,7 @@
 "@baruchiro/paperless-mcp": patch
 ---
 
-Fix the release workflow's npm upgrade step: install npm into a separate prefix instead of overwriting the running npm (which could fail mid-reify with "Cannot find module 'promise-retry'"), and pin to a trusted-publishing-compatible version (`npm@^11.5.1`) instead of `@latest`.
+Harden the release workflow:
+
+- Install npm into a separate prefix instead of overwriting the running npm (which could fail mid-reify with "Cannot find module 'promise-retry'"), and pin to a trusted-publishing-compatible version (`npm@^11.5.1`) instead of `@latest`.
+- Publish with `changeset publish` instead of raw `npm publish`, so a push to `main` with no pending changeset is a no-op instead of failing with "cannot publish over the previously published versions". Provenance is preserved via `NPM_CONFIG_PROVENANCE`, and `access` is set to `public` in the changesets config.

--- a/.changeset/fix-release-npm-upgrade.md
+++ b/.changeset/fix-release-npm-upgrade.md
@@ -6,3 +6,4 @@ Harden the release workflow:
 
 - Install npm into a separate prefix instead of overwriting the running npm (which could fail mid-reify with "Cannot find module 'promise-retry'"), and pin to a trusted-publishing-compatible version (`npm@^11.5.1`) instead of `@latest`.
 - Publish with `changeset publish` instead of raw `npm publish`, so a push to `main` with no pending changeset is a no-op instead of failing with "cannot publish over the previously published versions". Provenance is preserved via `NPM_CONFIG_PROVENANCE`, and `access` is set to `public` in the changesets config.
+- Only run the `docker-publish` job when a version was actually published: the version-extraction step now emits an empty string (instead of `null`) on a no-op run, and `docker-publish` is gated on a non-empty `versionTag`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Extract version from publishedPackages
         id: version
         run: |
-          echo "VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')" >> $GITHUB_OUTPUT
+          echo "VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages || '[]' }}' | jq -r '.[0].version // empty')" >> "$GITHUB_OUTPUT"
 
   docker-publish:
     needs: release
-    if: needs.release.outputs.hasChangesets == 'false'
+    if: needs.release.outputs.hasChangesets == 'false' && needs.release.outputs.versionTag != ''
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,14 @@ jobs:
           # registry, so a push to main with no pending changeset is a no-op
           # instead of failing with "cannot publish over 2.0.1" (raw
           # `npm publish` republishes the current version and errors).
-          publish: npx changeset publish
+          publish: npx --no-install changeset publish
       - name: Extract version from publishedPackages
         id: version
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages || '[]' }}
         run: |
-          echo "VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages || '[]' }}' | jq -r '.[0].version // empty')" >> "$GITHUB_OUTPUT"
+          version="$(printf '%s' "$PUBLISHED_PACKAGES" | jq -r '.[0].version // empty')"
+          printf 'VERSION=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
   docker-publish:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,14 @@ jobs:
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # changeset publish -> npm publish reads provenance from this env var.
+          NPM_CONFIG_PROVENANCE: true
         with:
-          publish: npm publish --provenance --access public
+          # `changeset publish` only publishes versions not already on the
+          # registry, so a push to main with no pending changeset is a no-op
+          # instead of failing with "cannot publish over 2.0.1" (raw
+          # `npm publish` republishes the current version and errors).
+          publish: npx changeset publish
       - name: Extract version from publishedPackages
         id: version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,16 @@ jobs:
         with:
           node-version-file: ".node-version"
           registry-url: https://registry.npmjs.org
-      - name: Update npm to latest version
-        run: npm install -g npm@latest
+      - name: Upgrade npm for OIDC trusted publishing
+        # `npm install -g npm@latest` overwrites the running npm mid-reify and
+        # can fail with "Cannot find module 'promise-retry'". Install npm into a
+        # separate prefix and prepend it to PATH instead of overwriting the
+        # bundled npm. Pin to a trusted-publishing-compatible version rather
+        # than @latest so a future npm release can't unexpectedly break the
+        # publish step.
+        run: |
+          npm install -g npm@^11.5.1 --prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: npm ci
       - name: Create Release Pull Request


### PR DESCRIPTION
Mirror the fix applied in israeli-bank-scrapers: `npm install -g npm@latest`
overwrites the running npm mid-reify and can crash with "Cannot find module
'promise-retry'". Install npm into a separate prefix and prepend it to PATH,
and pin to a trusted-publishing-compatible version (npm@^11.5.1) instead of
@latest so a future npm release can't unexpectedly break the publish step.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EDf8XZ3xGZUXALGrVZxRPr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Published package changesets are now publicly accessible.
  * Package releases use a more reliable publishing process with provenance metadata.
  * Docker publishing is skipped when no new package version is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->