### PR TITLE
fix(documents): bulk_edit_documents set_permissions sent the wrong parameter shape (always HTTP 500)

### DIFF
--- a/.changeset/fix-bulk-edit-set-permissions.md
+++ b/.changeset/fix-bulk-edit-set-permissions.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+fix(documents): `bulk_edit_documents` with `method: "set_permissions"` always failed with HTTP 500. The tool nested `set_permissions`/`owner`/`merge` under an extra `permissions` key, but Paperless reads them directly from `parameters`. The tool now takes `set_permissions`, `owner` and `merge` as top-level arguments matching the Paperless API, supports owner-only changes (sends the empty `set_permissions` object Paperless requires), and rejects a call with neither `set_permissions` nor `owner` instead of forwarding a request that would crash the server or silently clear ownership.

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ Parameters:
   - tag: ID for add_tag/remove_tag
   - add_tags: Array of tag IDs for modify_tags
   - remove_tags: Array of tag IDs for modify_tags
-  - permissions: Object for set_permissions with owner, permissions, merge flag
+  - set_permissions: Object for set_permissions with view/change users and groups (`{"view": {"users": [], "groups": []}, "change": {...}}`). Omitted actions/lists are left untouched
+  - owner: User ID (or null to remove) for set_permissions. Unless merge is true, omitting owner clears the current owner
+  - merge: Boolean for set_permissions — true adds to existing permissions and keeps the owner; false (default) replaces the listed users/groups
   - metadata_document_id: ID for merge to specify metadata source
   - delete_originals: Boolean for merge/split
   - pages: String for split "[1,2-3,4,5-7]" or delete_pages "[2,3,4]"

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -214,12 +214,10 @@ export interface BulkEditParameters {
   document_type?: number;
   storage_path?: number;
   tag?: number;
-  permissions?: {
-    owner?: number | null;
-    set_permissions?: {
-      view: { users: number[]; groups: number[] };
-      change: { users: number[]; groups: number[] };
-    };
-    merge?: boolean;
+  set_permissions?: {
+    view?: { users?: number[]; groups?: number[] };
+    change?: { users?: number[]; groups?: number[] };
   };
+  owner?: number | null;
+  merge?: boolean;
 }

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -713,4 +713,36 @@ describe("bulk_edit_documents set_permissions", () => {
 
     assert.equal(calls.bulkEditDocuments.length, 0);
   });
+
+  test("rejects malformed set_permissions input before calling Paperless", async () => {
+    const { api, calls } = createDocumentApi([]);
+
+    await withDocumentClient(api, async (client) => {
+      for (const set_permissions of [
+        { view: { groups: ["ai-agents"] } },
+        { read: { groups: [10] } },
+        { view: [10] },
+      ]) {
+        // Depending on the installed MCP SDK version, an input-schema (zod)
+        // violation either rejects with a protocol error (-32602) or resolves
+        // with a CallToolResult carrying isError: true.
+        let rejected = false;
+        let result: CallToolResult | undefined;
+        try {
+          result = (await client.callTool({
+            name: "bulk_edit_documents",
+            arguments: { documents: [1], method: "set_permissions", set_permissions },
+          })) as CallToolResult;
+        } catch {
+          rejected = true;
+        }
+        assert.ok(
+          rejected || result?.isError,
+          `expected ${JSON.stringify(set_permissions)} to be rejected`
+        );
+      }
+    });
+
+    assert.equal(calls.bulkEditDocuments.length, 0);
+  });
 });

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -618,3 +618,99 @@ describe("select custom field value resolution in document handlers", () => {
     );
   });
 });
+
+describe("bulk_edit_documents set_permissions", () => {
+  test("sends set_permissions, owner and merge at the top level of parameters", async () => {
+    const { api, calls } = createDocumentApi([]);
+
+    await withDocumentClient(api, async (client) => {
+      const result = (await client.callTool({
+        name: "bulk_edit_documents",
+        arguments: {
+          documents: [4103],
+          method: "set_permissions",
+          set_permissions: {
+            view: { users: [], groups: [10] },
+            change: { users: [], groups: [10] },
+          },
+          owner: 3,
+          merge: true,
+        },
+      })) as CallToolResult;
+      assert.ok(!result.isError, parseToolText(result)?.error);
+    });
+
+    assert.equal(calls.bulkEditDocuments.length, 1);
+    const [documents, method, parameters] = calls.bulkEditDocuments[0];
+    assert.deepEqual(documents, [4103]);
+    assert.equal(method, "set_permissions");
+    // Paperless reads parameters["set_permissions"] directly; nesting it under
+    // another key makes the server crash with a KeyError (HTTP 500).
+    assert.deepEqual(parameters, {
+      set_permissions: {
+        view: { users: [], groups: [10] },
+        change: { users: [], groups: [10] },
+      },
+      owner: 3,
+      merge: true,
+    });
+  });
+
+  test("forwards partial permissions without filling in omitted actions or lists", async () => {
+    const { api, calls } = createDocumentApi([]);
+
+    await withDocumentClient(api, async (client) => {
+      const result = (await client.callTool({
+        name: "bulk_edit_documents",
+        arguments: {
+          documents: [1],
+          method: "set_permissions",
+          set_permissions: { view: { groups: [10] } },
+        },
+      })) as CallToolResult;
+      assert.ok(!result.isError, parseToolText(result)?.error);
+    });
+
+    // Paperless only touches the actions/lists that are present, and clears
+    // the owner when it is omitted without merge — so nothing may be added.
+    const [, , parameters] = calls.bulkEditDocuments[0];
+    assert.deepEqual(parameters, { set_permissions: { view: { groups: [10] } } });
+  });
+
+  test("owner-only changes send an empty set_permissions object", async () => {
+    const { api, calls } = createDocumentApi([]);
+
+    await withDocumentClient(api, async (client) => {
+      for (const owner of [3, null]) {
+        const result = (await client.callTool({
+          name: "bulk_edit_documents",
+          arguments: { documents: [1], method: "set_permissions", owner },
+        })) as CallToolResult;
+        assert.ok(!result.isError, parseToolText(result)?.error);
+      }
+    });
+
+    assert.deepEqual(
+      calls.bulkEditDocuments.map(([, , parameters]) => parameters),
+      [
+        { set_permissions: {}, owner: 3 },
+        { set_permissions: {}, owner: null },
+      ]
+    );
+  });
+
+  test("rejects method set_permissions with neither set_permissions nor owner", async () => {
+    const { api, calls } = createDocumentApi([]);
+
+    await withDocumentClient(api, async (client) => {
+      const result = (await client.callTool({
+        name: "bulk_edit_documents",
+        arguments: { documents: [1], method: "set_permissions", merge: true },
+      })) as CallToolResult;
+      assert.ok(result.isError, "expected an error when both are missing");
+      assert.match(parseToolText(result)?.error ?? "", /set_permissions and\/or owner/);
+    });
+
+    assert.equal(calls.bulkEditDocuments.length, 0);
+  });
+});

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -5,7 +5,7 @@ import { constants } from "fs";
 import { basename, isAbsolute } from "path";
 import { convertDocsWithNames } from "../api/documentEnhancer";
 import { PaperlessAPI } from "../api/PaperlessAPI";
-import { arrayNotEmpty, objectNotEmpty } from "./utils/empty";
+import { arrayNotEmpty } from "./utils/empty";
 import {
   BuildDocumentQueryArgs,
   buildDocumentQueryString,
@@ -193,25 +193,38 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
         .array(z.number())
         .optional()
         .transform(arrayNotEmpty),
-      permissions: z
+      set_permissions: z
         .object({
-          owner: z.number().nullable().optional(),
-          set_permissions: z
+          view: z
             .object({
-              view: z.object({
-                users: z.array(z.number()),
-                groups: z.array(z.number()),
-              }),
-              change: z.object({
-                users: z.array(z.number()),
-                groups: z.array(z.number()),
-              }),
+              users: z.array(z.number()).optional(),
+              groups: z.array(z.number()).optional(),
             })
             .optional(),
-          merge: z.boolean().optional(),
+          change: z
+            .object({
+              users: z.array(z.number()).optional(),
+              groups: z.array(z.number()).optional(),
+            })
+            .optional(),
         })
         .optional()
-        .transform(objectNotEmpty),
+        .describe(
+          "For set_permissions: view/change permissions to apply. Omitted actions (view/change) and omitted users/groups lists are left untouched; an empty list [] removes all (unless merge is true). Omit entirely for owner-only changes."
+        ),
+      owner: z
+        .number()
+        .nullable()
+        .optional()
+        .describe(
+          "For set_permissions: new owner user ID, or null to remove the owner. Unless merge is true, omitting owner also clears the current owner."
+        ),
+      merge: z
+        .boolean()
+        .optional()
+        .describe(
+          "For set_permissions: true adds to existing permissions and keeps the current owner; false (default) replaces the listed users/groups"
+        ),
       metadata_document_id: z.number().optional(),
       delete_originals: z.boolean().optional(),
       pages: z.string().optional(),
@@ -230,7 +243,21 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
           "Confirmation required for destructive operation. Set confirm: true to proceed."
         );
       }
+      if (
+        args.method === "set_permissions" &&
+        !args.set_permissions &&
+        args.owner === undefined
+      ) {
+        throw new Error(
+          "Method 'set_permissions' requires set_permissions and/or owner."
+        );
+      }
       const { documents, method, add_custom_fields, confirm, ...parameters } = args;
+      if (method === "set_permissions") {
+        // Paperless rejects (Paperless <= 3.0.5: crashes with a 500 on) a missing
+        // set_permissions key even for owner-only changes.
+        parameters.set_permissions ??= {};
+      }
 
       validateCustomFields(add_custom_fields);
       const resolvedCustomFields = await resolveSelectCustomFieldValues(

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -200,14 +200,19 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
               users: z.array(z.number()).optional(),
               groups: z.array(z.number()).optional(),
             })
+            .strict()
             .optional(),
           change: z
             .object({
               users: z.array(z.number()).optional(),
               groups: z.array(z.number()).optional(),
             })
+            .strict()
             .optional(),
         })
+        // strict: a misspelled action ("read") must not silently collapse
+        // into {} and clear permissions/ownership.
+        .strict()
         .optional()
         .describe(
           "For set_permissions: view/change permissions to apply. Omitted actions (view/change) and omitted users/groups lists are left untouched; an empty list [] removes all (unless merge is true). Omit entirely for owner-only changes."


### PR DESCRIPTION
## Problem

`bulk_edit_documents` with `method: "set_permissions"` always fails with HTTP 500 from Paperless, regardless of payload. Reproduced with the minimal call:

```json
{ "documents": [4103], "method": "set_permissions",
  "permissions": { "set_permissions": { "view": { "users": [], "groups": [10] }, "change": { "users": [], "groups": [10] } } } }
```

The tool nests everything under a `permissions` key, so the request body sent to Paperless is

```json
{ "documents": [4103], "method": "set_permissions",
  "parameters": { "permissions": { "set_permissions": { ... }, "owner": 3, "merge": true } } }
```

but Paperless reads `parameters["set_permissions"]`, `parameters["owner"]` and `parameters["merge"]` directly (see [`_validate_parameters_set_permissions`](https://github.com/paperless-ngx/paperless-ngx/blob/v3.0.5/src/documents/serialisers.py#L1978) and the [bulk edit docs](https://docs.paperless-ngx.com/api/#bulk-editing)). On Paperless ≤ 3.0.5 that is an unhandled `KeyError: 'set_permissions'` → 500; on `dev` (paperless-ngx/paperless-ngx#13563) it becomes a 400 `set_permissions not specified`. Either way the tool can never succeed.

## Fix

- `set_permissions`, `owner` and `merge` are now top-level tool arguments, matching the shape Paperless expects in `parameters` (per the repo guideline "keep tool inputs close to the API"). `users`/`groups` and `view`/`change` are optional, as Paperless leaves omitted parts untouched.
- Owner-only changes (`owner` without `set_permissions`) work: the tool sends the empty `set_permissions: {}` that Paperless requires. A call with neither `set_permissions` nor `owner` is rejected with a clear error instead of forwarding a request that 500s on current Paperless releases (and would otherwise clear ownership).
- Parameter descriptions document the non-obvious Paperless semantics (omitting `owner` without `merge: true` clears the owner).
- `BulkEditParameters` type and README updated; changeset added (patch).

Note: `bulk_edit_tags` / `bulk_edit_correspondents` / `bulk_edit_document_types` were checked and are correct — `/api/bulk_edit_objects/` takes `owner`/`permissions`/`merge` at the top level, which they already send.

## Tests

- New handler-level tests in `src/tools/documents.test.ts` assert the exact `parameters` object handed to `PaperlessAPI.bulkEditDocuments` (no `permissions` wrapper), that partial payloads are forwarded without filling in omitted actions/lists or an owner, the owner-only case (`3` and `null`), and the neither-given error. `npm test`: 51/51 pass.
- Verified end-to-end against a live Paperless-ngx 3.0.5: the same call that produced the 500 with 2.0.1 returns `{"result":"OK"}` with this branch (both the full and the owner-only form), and the document's owner/permissions came out as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated bulk document editing to support top-level permission and owner updates.
  - Added support for owner-only changes, including clearing an owner.
  - Permission updates can now be partial and support merge or replace behavior.

- **Bug Fixes**
  - Rejects bulk edit requests that provide neither permissions nor owner information.

- **Documentation**
  - Updated bulk editing guidance to reflect the revised permission and owner options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->