### PR TITLE
Surface resource URIs as text in document download/thumbnail tools

### DIFF
--- a/.changeset/olive-pugs-listen.md
+++ b/.changeset/olive-pugs-listen.md
@@ -1,0 +1,13 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+Surface the resource URI as text in `download_document` and `get_document_thumbnail` (#134).
+
+Both tools returned a single `resource` content block, so MCP clients that read
+only `content[].text` and drop resource blocks (Hermes Agent, older Claude
+Desktop) saw an empty result and never learned the URI. Each tool now also
+returns the bare `paperless://` URI in a leading `text` block. The resource block
+is unchanged, so clients that already follow it keep working.
+
+Thanks to @zbingos for the report and diagnosis.

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -31,6 +31,10 @@ import {
   CustomFieldQuery,
   DOCUMENT_QUERY_PAPERLESS_FILTER_KEYS,
 } from "./utils/documentQuery";
+import {
+  buildDocumentResourceUri,
+  buildThumbnailResourceUri,
+} from "./utils/resourceUri";
 
 function getQueryParams(queryString: string) {
   return new URLSearchParams(queryString.replace(/^\?/, ""));
@@ -620,75 +624,56 @@ describe("select custom field value resolution in document handlers", () => {
 });
 
 describe("document resource reference tools", () => {
-  async function callResourceTool(
-    name: string,
-    args: Record<string, unknown>
-  ): Promise<CallToolResult> {
-    const { api } = createDocumentApi([]);
-    let result: CallToolResult | undefined;
-    await withDocumentClient(api, async (client) => {
-      result = (await client.callTool({
-        name,
-        arguments: args,
-      })) as CallToolResult;
+  // Expected URIs come from the builders rather than literals: their exact
+  // format is already pinned by utils/resourceUri.test.ts, and what matters
+  // here is that the handler surfaces that URI in both content blocks.
+  const cases = [
+    {
+      tool: "download_document",
+      args: { id: 4 },
+      uri: buildDocumentResourceUri(4),
+      mimeType: "application/octet-stream",
+    },
+    {
+      tool: "download_document",
+      args: { id: 4, original: true },
+      uri: buildDocumentResourceUri(4, { original: true }),
+      mimeType: "application/octet-stream",
+    },
+    {
+      tool: "get_document_thumbnail",
+      args: { id: 123 },
+      uri: buildThumbnailResourceUri(123),
+      mimeType: "image/webp",
+    },
+  ];
+
+  for (const { tool, args, uri, mimeType } of cases) {
+    test(`${tool} ${JSON.stringify(args)} returns the URI as text beside the resource`, async () => {
+      const { api } = createDocumentApi([]);
+      let result: CallToolResult | undefined;
+      await withDocumentClient(api, async (client) => {
+        result = (await client.callTool({
+          name: tool,
+          arguments: args,
+        })) as CallToolResult;
+      });
+
+      assert.ok(result && !result.isError, `${tool} failed`);
+      const [text, embedded] = result.content;
+
+      // Legacy clients read only content[].text (issue #134).
+      assert.equal(text.type, "text");
+      assert.equal(text.text, uri);
+
+      assert.equal(embedded.type, "resource");
+      const { resource } = embedded as {
+        resource: { uri: string; mimeType: string };
+      };
+      assert.equal(resource.uri, uri, "both blocks must reference the same URI");
+      assert.equal(resource.mimeType, mimeType);
     });
-    assert.ok(result, `${name} returned no result`);
-    // parseToolText assumes a JSON payload; these tools return a bare URI.
-    assert.ok(!result.isError, `${name} failed`);
-    return result;
   }
-
-  function assertUriBlocks(
-    result: CallToolResult,
-    expectedUri: string,
-    expectedMimeType: string
-  ) {
-    const [text, embedded] = result.content;
-
-    assert.equal(text.type, "text");
-    assert.equal(
-      text.text,
-      expectedUri,
-      "the text block must carry the bare URI so clients that drop resource blocks still see it"
-    );
-
-    assert.equal(embedded.type, "resource");
-    assert.equal(
-      (embedded as { resource: { uri: string } }).resource.uri,
-      expectedUri,
-      "both blocks must reference the same URI"
-    );
-    assert.equal(
-      (embedded as { resource: { mimeType: string } }).resource.mimeType,
-      expectedMimeType
-    );
-  }
-
-  test("download_document exposes the URI as text alongside the resource", async () => {
-    const result = await callResourceTool("download_document", { id: 4 });
-    assertUriBlocks(
-      result,
-      "paperless://documents/4/download",
-      "application/octet-stream"
-    );
-  });
-
-  test("download_document keeps the original flag in the text URI", async () => {
-    const result = await callResourceTool("download_document", {
-      id: 4,
-      original: true,
-    });
-    assertUriBlocks(
-      result,
-      "paperless://documents/4/download?original=true",
-      "application/octet-stream"
-    );
-  });
-
-  test("get_document_thumbnail exposes the URI as text alongside the resource", async () => {
-    const result = await callResourceTool("get_document_thumbnail", { id: 123 });
-    assertUriBlocks(result, "paperless://documents/123/thumb", "image/webp");
-  });
 });
 
 describe("bulk_edit_documents set_permissions", () => {

--- a/src/tools/documents.test.ts
+++ b/src/tools/documents.test.ts
@@ -618,3 +618,75 @@ describe("select custom field value resolution in document handlers", () => {
     );
   });
 });
+
+describe("document resource reference tools", () => {
+  async function callResourceTool(
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<CallToolResult> {
+    const { api } = createDocumentApi([]);
+    let result: CallToolResult | undefined;
+    await withDocumentClient(api, async (client) => {
+      result = (await client.callTool({
+        name,
+        arguments: args,
+      })) as CallToolResult;
+    });
+    assert.ok(result, `${name} returned no result`);
+    // parseToolText assumes a JSON payload; these tools return a bare URI.
+    assert.ok(!result.isError, `${name} failed`);
+    return result;
+  }
+
+  function assertUriBlocks(
+    result: CallToolResult,
+    expectedUri: string,
+    expectedMimeType: string
+  ) {
+    const [text, embedded] = result.content;
+
+    assert.equal(text.type, "text");
+    assert.equal(
+      text.text,
+      expectedUri,
+      "the text block must carry the bare URI so clients that drop resource blocks still see it"
+    );
+
+    assert.equal(embedded.type, "resource");
+    assert.equal(
+      (embedded as { resource: { uri: string } }).resource.uri,
+      expectedUri,
+      "both blocks must reference the same URI"
+    );
+    assert.equal(
+      (embedded as { resource: { mimeType: string } }).resource.mimeType,
+      expectedMimeType
+    );
+  }
+
+  test("download_document exposes the URI as text alongside the resource", async () => {
+    const result = await callResourceTool("download_document", { id: 4 });
+    assertUriBlocks(
+      result,
+      "paperless://documents/4/download",
+      "application/octet-stream"
+    );
+  });
+
+  test("download_document keeps the original flag in the text URI", async () => {
+    const result = await callResourceTool("download_document", {
+      id: 4,
+      original: true,
+    });
+    assertUriBlocks(
+      result,
+      "paperless://documents/4/download?original=true",
+      "application/octet-stream"
+    );
+  });
+
+  test("get_document_thumbnail exposes the URI as text alongside the resource", async () => {
+    const result = await callResourceTool("get_document_thumbnail", { id: 123 });
+    assertUriBlocks(result, "paperless://documents/123/thumb", "image/webp");
+  });
+});

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -477,6 +477,9 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       });
       return {
         content: [
+          // Clients that only surface content[].text drop resource blocks
+          // entirely, so the URI is repeated here to stay reachable (issue #134).
+          { type: "text", text: uri },
           {
             type: "resource",
             resource: {
@@ -501,12 +504,16 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
+      const uri = buildThumbnailResourceUri(args.id);
       return {
         content: [
+          // See download_document above: the URI is repeated as text for clients
+          // that drop resource blocks.
+          { type: "text", text: uri },
           {
             type: "resource",
             resource: {
-              uri: buildThumbnailResourceUri(args.id),
+              uri,
               // See download_document above: the binary thumbnail is fetched
               // lazily through resources/read instead of embedded here.
               text: "",

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -509,7 +509,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       });
       return {
         content: [
-          // Clients that only surface content[].text drop resource blocks
+          // Legacy clients surface only content[].text and drop resource blocks
           // entirely, so the URI is repeated here to stay reachable (issue #134).
           { type: "text", text: uri },
           {
@@ -539,8 +539,8 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
       const uri = buildThumbnailResourceUri(args.id);
       return {
         content: [
-          // See download_document above: the URI is repeated as text for clients
-          // that drop resource blocks.
+          // See download_document above: the URI is repeated as text for legacy
+          // clients that drop resource blocks.
           { type: "text", text: uri },
           {
             type: "resource",


### PR DESCRIPTION
## Summary
Fixes issue #134 where MCP clients that only read `content[].text` and drop resource blocks (Hermes Agent, older Claude Desktop) received empty results from `download_document` and `get_document_thumbnail` tools because the URI was only present in the resource block.

## Changes
- **`download_document` tool**: Now returns the `paperless://documents/{id}/download` URI as a leading text block alongside the existing resource block
- **`get_document_thumbnail` tool**: Now returns the `paperless://documents/{id}/thumb` URI as a leading text block alongside the existing resource block
- Both tools preserve the original `original=true` query parameter in the text URI when specified
- Added comprehensive test coverage for both tools verifying that:
  - The URI appears in both text and resource blocks
  - The MIME types are correct (`application/octet-stream` for downloads, `image/webp` for thumbnails)
  - The `original` flag is preserved in the text URI

## Implementation Details
The URI is now duplicated across two content blocks:
1. A `text` block containing the bare `paperless://` URI (for clients that drop resource blocks)
2. A `resource` block with the URI and MIME type (for clients that follow resource blocks)

This ensures backward compatibility—clients already following resource blocks continue to work unchanged, while clients that only surface text content now see the URI.

https://claude.ai/code/session_01XeXEHFYZQ3WQmcwEtEkC94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Document downloads and thumbnails now include a direct `paperless://` URI in a leading text block, while retaining the existing resource content.
  - Returned resource references continue to include the appropriate document or thumbnail content and MIME type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->