### PR TITLE
fix(schema): collapse nullable union types for strict MCP clients (#138)

### DIFF
--- a/.changeset/collapse-nullable-union-types.md
+++ b/.changeset/collapse-nullable-union-types.md
@@ -1,0 +1,5 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+fix(schema): advertise scalar `type`s for `.nullable()` fields so strict MCP clients keep the tools. `zod-to-json-schema` renders `.nullable()` params as `"type": ["T", "null"]`, which is valid JSON Schema but is rejected by strict MCP clients and gateways (e.g. the Kuadrant mcp-gateway broker), silently dropping `update_document`, `create_mail_rule`, and `update_mail_rule`. The `tools/list` output now collapses `["T", "null"]` unions to a scalar `"T"`; the underlying zod schemas are unchanged, so the server still accepts `null` at call time to clear fields. Fixes #138.

--- a/src/server.schema.test.ts
+++ b/src/server.schema.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types";
+import { createMcpServer } from "./server";
+
+class TestTransport implements Transport {
+  peer?: TestTransport;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  async start(): Promise<void> {}
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    queueMicrotask(() => this.peer?.onmessage?.(message));
+  }
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+}
+
+function createTransportPair() {
+  const clientTransport = new TestTransport();
+  const serverTransport = new TestTransport();
+  clientTransport.peer = serverTransport;
+  serverTransport.peer = clientTransport;
+  return { clientTransport, serverTransport };
+}
+
+// A property `type` must never be advertised as a `["T","null"]` union — see #138.
+function assertNoNullableUnions(schema: unknown, path: string): void {
+  if (Array.isArray(schema)) {
+    schema.forEach((item, i) => assertNoNullableUnions(item, `${path}[${i}]`));
+    return;
+  }
+  if (schema === null || typeof schema !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (key === "type" && Array.isArray(value)) {
+      assert.ok(
+        !value.includes("null"),
+        `${path}.type advertises a nullable union ${JSON.stringify(value)}`
+      );
+    } else {
+      assertNoNullableUnions(value, `${path}.${key}`);
+    }
+  }
+}
+
+test("createMcpServer advertises scalar types for nullable fields (#138)", async () => {
+  const server = createMcpServer({
+    baseUrl: "http://paperless.test",
+    token: "test-token",
+    version: "0.0.0-test",
+    publicUrl: "http://paperless.test",
+  });
+
+  const client = new Client({ name: "schema-test-client", version: "1.0.0" });
+  const { clientTransport, serverTransport } = createTransportPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    const { tools } = await client.listTools();
+
+    // Every tool schema must be free of nullable unions.
+    for (const tool of tools) {
+      assertNoNullableUnions(tool.inputSchema, tool.name);
+    }
+
+    // Spot-check the tools that regressed in #138.
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+    for (const name of ["update_document", "create_mail_rule", "update_mail_rule"]) {
+      const tool = byName.get(name);
+      assert.ok(tool, `expected tool ${name} to be registered`);
+    }
+
+    const updateDocument = byName.get("update_document")!;
+    const props = (updateDocument.inputSchema as {
+      properties: Record<string, { type?: unknown }>;
+    }).properties;
+    assert.equal(props.owner.type, "number");
+    assert.equal(props.correspondent.type, "number");
+    assert.equal(props.document_type.type, "number");
+    assert.equal(props.storage_path.type, "number");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { registerDocumentTypeTools } from "./tools/documentTypes";
 import { registerMailTools } from "./tools/mail";
 import { registerNoteTools } from "./tools/notes";
 import { registerTagTools } from "./tools/tags";
+import { sanitizeToolSchemas } from "./tools/utils/nullableSchema";
 
 export interface CreateMcpServerOptions {
   baseUrl: string;
@@ -36,6 +37,9 @@ export function createMcpServer({
   registerDocumentTypeTools(server, api);
   registerCustomFieldTools(server, api);
   registerMailTools(server, api);
+  // Collapse `.nullable()` union types (`type: ["T","null"]`) in the advertised
+  // tool schemas to scalar types for strict MCP clients. See issue #138.
+  sanitizeToolSchemas(server);
   return server;
 }
 

--- a/src/tools/utils/nullableSchema.test.ts
+++ b/src/tools/utils/nullableSchema.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { collapseNullableTypes } from "./nullableSchema";
+
+test("collapses ['T','null'] to a scalar type", () => {
+  assert.deepEqual(collapseNullableTypes({ type: ["string", "null"] }), {
+    type: "string",
+  });
+  assert.deepEqual(collapseNullableTypes({ type: ["number", "null"] }), {
+    type: "number",
+  });
+});
+
+test("collapses nullable types nested in object properties", () => {
+  const input = {
+    type: "object",
+    properties: {
+      filter_from: { type: ["string", "null"] },
+      name: { type: "string" },
+      owner: { type: ["number", "null"] },
+    },
+  };
+  assert.deepEqual(collapseNullableTypes(input), {
+    type: "object",
+    properties: {
+      filter_from: { type: "string" },
+      name: { type: "string" },
+      owner: { type: "number" },
+    },
+  });
+});
+
+test("collapses nullable types inside array item schemas", () => {
+  const input = {
+    type: "array",
+    items: { type: ["number", "null"] },
+  };
+  assert.deepEqual(collapseNullableTypes(input), {
+    type: "array",
+    items: { type: "number" },
+  });
+});
+
+test("preserves genuine multi-type unions that do not include null", () => {
+  const input = { type: ["string", "number"] };
+  assert.deepEqual(collapseNullableTypes(input), { type: ["string", "number"] });
+});
+
+test("strips 'null' from a multi-type union but keeps the remaining union", () => {
+  const input = { type: ["string", "number", "null"] };
+  assert.deepEqual(collapseNullableTypes(input), { type: ["string", "number"] });
+});
+
+test("leaves anyOf-style nullable unions untouched", () => {
+  const input = {
+    anyOf: [{ type: "string" }, { type: "null" }],
+  };
+  assert.deepEqual(collapseNullableTypes(input), {
+    anyOf: [{ type: "string" }, { type: "null" }],
+  });
+});
+
+test("does not mutate the input schema", () => {
+  const input = { type: ["string", "null"] as (string | null)[] };
+  const snapshot = JSON.parse(JSON.stringify(input));
+  collapseNullableTypes(input);
+  assert.deepEqual(input, snapshot);
+});
+
+test("passes through primitives and null", () => {
+  assert.equal(collapseNullableTypes("string"), "string");
+  assert.equal(collapseNullableTypes(42), 42);
+  assert.equal(collapseNullableTypes(null), null);
+});

--- a/src/tools/utils/nullableSchema.ts
+++ b/src/tools/utils/nullableSchema.ts
@@ -1,0 +1,86 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Recursively collapse JSON-Schema nullable unions (`"type": ["T", "null"]`)
+ * back into a scalar `"type": "T"`.
+ *
+ * `zod-to-json-schema` renders `z.T().nullable()` as `{ "type": ["T", "null"] }`.
+ * That is valid JSON Schema, but the MCP tool `inputSchema` convention — and
+ * several strict MCP clients / gateways (e.g. the Kuadrant mcp-gateway broker,
+ * which drops any tool whose schema uses the array form) — expect a scalar
+ * `type`. See issue #138.
+ *
+ * Only the *advertised* schema is relaxed: the underlying zod schema is
+ * untouched, so the server still accepts `null` at call time (used to clear
+ * fields on PATCH). `"null"` is stripped from every `type` array; if a single
+ * type remains it is collapsed to a scalar, otherwise the remaining (genuine)
+ * union is preserved.
+ */
+export function collapseNullableTypes<T>(schema: T): T {
+  if (Array.isArray(schema)) {
+    return schema.map((item) => collapseNullableTypes(item)) as unknown as T;
+  }
+  if (schema === null || typeof schema !== "object") {
+    return schema;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (key === "type" && Array.isArray(value) && value.includes("null")) {
+      const nonNull = value.filter((entry) => entry !== "null");
+      result[key] =
+        nonNull.length === 1
+          ? nonNull[0]
+          : nonNull.length > 0
+            ? nonNull
+            : value;
+    } else {
+      result[key] = collapseNullableTypes(value);
+    }
+  }
+  return result as T;
+}
+
+/**
+ * Post-process an `McpServer`'s `tools/list` output so every tool's
+ * `inputSchema` uses scalar types instead of `["T", "null"]` unions.
+ *
+ * The high-level `McpServer` computes each schema via
+ * `zodToJsonSchema(shape, { strictUnions: true })` and exposes no hook to change
+ * those options or transform the result, so we wrap the already-registered
+ * low-level `tools/list` handler. `server.server` is public API; the handler map
+ * is internal and accessed narrowly here. Call once, after all tools are
+ * registered. See issue #138.
+ */
+export function sanitizeToolSchemas(server: McpServer): void {
+  const method = ListToolsRequestSchema.shape.method.value;
+  const requestHandlers = (
+    server.server as unknown as {
+      _requestHandlers: Map<
+        string,
+        (
+          request: unknown,
+          extra: unknown
+        ) => Promise<{ tools?: Array<{ inputSchema?: unknown }> }>
+      >;
+    }
+  )._requestHandlers;
+
+  const original = requestHandlers.get(method);
+  if (!original) {
+    return;
+  }
+
+  requestHandlers.set(method, async (request, extra) => {
+    const result = await original(request, extra);
+    if (result && Array.isArray(result.tools)) {
+      for (const tool of result.tools) {
+        if (tool.inputSchema) {
+          tool.inputSchema = collapseNullableTypes(tool.inputSchema);
+        }
+      }
+    }
+    return result;
+  });
+}


### PR DESCRIPTION
Fixes #138.

## Problem

`zod-to-json-schema` renders `.nullable()` params as `"type": ["T", "null"]`. That is valid JSON Schema, but the MCP tool `inputSchema` convention — and several strict MCP clients / gateways — expect a **scalar** `type` and drop any tool whose schema uses the array form.

Concretely, the [Kuadrant mcp-gateway](https://github.com/Kuadrant/mcp-gateway) broker logs `invalid tools detected` and silently de-federates the three tools that use `z.T().nullable().optional()`:

- `update_document` (`owner`, `correspondent`, `document_type`, `storage_path`)
- `create_mail_rule` / `update_mail_rule` (`filter_*`, `action_parameter`)

```
level=ERROR msg="invalid tool" tool=update_document errors=[inputSchema.properties["owner"].type must be a string, got []interface {} ...]
level=ERROR msg="invalid tools detected" invalid=3 valid=41
```

## Fix

Post-process the `tools/list` output so every tool `inputSchema` collapses `["T", "null"]` unions back to a scalar `"T"`, recursively (nested object properties and array items included). `"null"` is stripped from any `type` array; a single remaining type collapses to a scalar, a genuine multi-type union is preserved.

The underlying zod schemas are **untouched**, so the server still accepts `null` at call time to clear fields on PATCH — only the advertised schema is relaxed. This is the schema-post-processing approach suggested in the issue (rather than swapping `.nullable()` for `.optional()`, which would drop the ability to clear a field).

### Why a post-processor rather than SDK options

The high-level `McpServer` computes each schema via `zodToJsonSchema(shape, { strictUnions: true })` and exposes no hook to change those options or transform the result, so the fix wraps the already-registered low-level `tools/list` handler once, after all tools are registered (`src/tools/utils/nullableSchema.ts`). If a cleaner public hook lands in the MCP SDK, this can be simplified.

## Tests

- `src/tools/utils/nullableSchema.test.ts` — unit tests for the recursive collapse helper (scalar collapse, nested properties, array items, genuine unions preserved, `anyOf` left alone, input not mutated).
- `src/server.schema.test.ts` — integration test: builds the full server via `createMcpServer`, lists tools over an in-memory transport, and asserts no tool advertises a nullable union and the previously-affected `update_document` fields are scalar.

Full suite green (`npm test`): 98 passing.

Co-authored with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with strict MCP clients and gateways by normalizing nullable tool parameter schemas.
  * Restored visibility of document and mail-rule tools in supported integrations.
  * Preserved the ability to use `null` when clearing supported fields.

* **Tests**
  * Added coverage for nested schemas, arrays, unions, and tool registration to ensure schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->