### PR TITLE
ci(docker): publish semver tags (2.0.1, 2.0, 2) alongside latest (#139)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,17 +45,37 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set semver and latest tags if release
         id: tagmeta
+        env:
+          VERSION_TAG: ${{ inputs.versionTag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_call" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "LATEST=type=raw,value=latest" >> $GITHUB_OUTPUT
+            echo "LATEST=type=raw,value=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "LATEST=" >> $GITHUB_OUTPUT
+            echo "LATEST=" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "SEMVER=type=semver,pattern=${{ inputs.versionTag }}" >> $GITHUB_OUTPUT
+          # Emit immutable semver tags from the published version.
+          # type=semver derives its version from a git tag ref, which
+          # this changesets-on-main flow never creates, so emit the
+          # tags as type=raw. A prerelease (contains '-') gets only its
+          # exact tag; the floating major / major.minor tags are never
+          # moved to a prerelease.
+          if [ "${{ github.event_name }}" = "workflow_call" ] &&
+             [ -n "$VERSION_TAG" ]; then
+            {
+              echo "SEMVER<<SEMVER_EOF"
+              echo "type=raw,value=${VERSION_TAG}"
+              case "$VERSION_TAG" in
+                *-*) ;;  # prerelease: exact tag only
+                *)
+                  echo "type=raw,value=${VERSION_TAG%.*}"
+                  echo "type=raw,value=${VERSION_TAG%%.*}"
+                  ;;
+              esac
+              echo "SEMVER_EOF"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "SEMVER=" >> $GITHUB_OUTPUT
+            echo "SEMVER=" >> "$GITHUB_OUTPUT"
           fi
       - name: Extract Docker metadata
         id: meta


### PR DESCRIPTION
## Problem

Fixes #139. `ghcr.io/baruchiro/paperless-mcp` publishes only `latest` and `sha-<commit>` — **no semver tags** (`2.0.1`, `2.0`, `2`), so consumers can't pin to a stable minor/patch.

Root cause: `release.yml` passes the published version to `docker-publish.yml` as `type=semver,pattern=${{ inputs.versionTag }}`, but `docker/metadata-action`'s `type=semver` reads its version from a **git tag ref** (which the changesets-on-`main` release flow never creates), and `pattern` is a *format template*, not a literal version. The step therefore emits nothing.

## Change

In the `tagmeta` step, derive the tags from the published version and emit them as immutable `type=raw` tags:
- `<version>` (e.g. `2.0.1`)
- `<major>.<minor>` (e.g. `2.0`)
- `<major>` (e.g. `2`)

Also passes `versionTag` via an `env:` var instead of inline `${{ }}` interpolation into the shell (safer, and quiets the injection lint).

Version parsing is pure shell parameter expansion, verified:

| version | tags |
|---|---|
| `2.0.1` | `2.0.1`, `2.0`, `2` |
| `2.13.0` | `2.13.0`, `2.13`, `2` |

Only fires on the `workflow_call` from a release with a non-empty `versionTag`; PR/`latest`/`sha` tagging is unchanged.

## Verification note

This is a release-workflow change, so it can't be exercised without cutting a release. I verified the YAML parses and the tag-derivation logic locally; a maintainer's eye on the release path is welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Docker image version tags for releases, including full, major-minor, and major versions.
  * Preserved the `LATEST` tag behavior.
  * Prevented semantic version tags from being emitted for pull request builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->