### PR TITLE
Ship only production dependencies and bump axios

### DIFF
--- a/.changeset/drop-dev-deps-and-bump-axios.md
+++ b/.changeset/drop-dev-deps-and-bump-axios.md
@@ -1,0 +1,9 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Ship only production dependencies in the container image and bump axios
+
+The production stage inherited `node_modules` from the builder, which ran `npm ci` and therefore installed devDependencies too — 196 packages where the compiled entrypoint needs 103. `npm prune --omit=dev` drops them before the copy. axios was separately held at 1.9.0 by the lockfile although the declared range already allowed the fixed releases.
+
+Together these take the image from 81 advisories with a fix available (2 critical) down to 20 (0 critical).

--- a/.changeset/drop-dev-deps-and-bump-axios.md
+++ b/.changeset/drop-dev-deps-and-bump-axios.md
@@ -4,6 +4,6 @@
 
 Ship only production dependencies in the container image and bump axios
 
-The production stage inherited `node_modules` from the builder, which ran `npm ci` and therefore installed devDependencies too — 196 packages where the compiled entrypoint needs 103. `npm prune --omit=dev` drops them before the copy. axios was separately held at 1.9.0 by the lockfile although the declared range already allowed the fixed releases.
+The production stage inherited `node_modules` from the builder, which ran `npm ci` and therefore installed devDependencies too — 261 installed packages instead of the 95 the compiled entrypoint needs. `npm prune --omit=dev` drops them before the copy. axios was separately held at 1.9.0 by the lockfile although the declared range already allowed the fixed releases.
 
 Together these take the image from 81 advisories with a fix available (2 critical) down to 20 (0 critical).

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ COPY . .
 RUN npm run build
 
 # The production stage copies node_modules from here. Without pruning, the
-# devDependencies ship with it -- typescript, ts-node and their tree, 196
-# packages where the compiled entrypoint needs 31.
+# devDependencies ship with it -- typescript, ts-node and their tree: 261
+# installed packages instead of the 95 the compiled entrypoint needs.
+# (Counted as package.json files directly under a node_modules directory,
+# cross-checked against `npm ls --omit=dev --all`.)
 RUN npm prune --omit=dev
 
 # Production stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
+# The production stage copies node_modules from here. Without pruning, the
+# devDependencies ship with it -- typescript, ts-node and their tree, 196
+# packages where the compiled entrypoint needs 31.
+RUN npm prune --omit=dev
+
 # Production stage
 FROM node:24-slim AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# The production stage copies node_modules from here. Without pruning, the
-# devDependencies ship with it -- typescript, ts-node and their tree: 277
-# installed packages instead of the 108 the compiled entrypoint needs.
-# (Counted as package.json files directly under a node_modules directory,
-# cross-checked against `npm ls --omit=dev --all`.)
 RUN npm prune --omit=dev
 
 # Production stage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@baruchiro/paperless-mcp",
-  "version": "0.5.1",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baruchiro/paperless-mcp",
-      "version": "0.5.1",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.1",
-        "axios": "^1.9.0",
+        "axios": "^1.20.0",
         "express": "^5.1.0",
         "form-data": "^4.0.2",
         "typescript": "^5.8.3",
@@ -865,6 +865,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -945,13 +957,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/better-path-resolve": {
@@ -1577,15 +1591,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1596,14 +1611,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1829,9 +1846,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1852,6 +1870,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-id": {
@@ -2360,9 +2391,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.1",
-    "axios": "^1.9.0",
+    "axios": "^1.20.0",
     "express": "^5.1.0",
     "form-data": "^4.0.2",
     "typescript": "^5.8.3",


### PR DESCRIPTION
A Trivy scan of the published image (`ghcr.io/baruchiro/paperless-mcp:sha-6ca70ca`) reports **81 advisories that have a fix available**, 2 of them critical. They come from two independent causes, and neither needs a source change.

## 1. The image ships devDependencies

The production stage copies `node_modules` from the builder, and the builder ran `npm ci`, which installs devDependencies as well. The published image therefore carries **261 packages** — `typescript`, `ts-node`, `node-forge`, `js-yaml` and their trees — where the compiled entrypoint `node build/index.js` needs **95**.

> Counted as every `package.json` directly under a `node_modules` directory, so nested installs and scoped packages are included. `npm ls --omit=dev --all` reports the same 95 for the production tree.

One `npm prune --omit=dev` in the builder, before the copy, drops them.

## 2. axios was held at 1.9.0 by the lockfile

The declared range `^1.9.0` already allowed every fixed release; only `package-lock.json` pinned it. Refreshed to 1.20.0 (range updated to `^1.20.0` to make the floor explicit).

## Effect

Fixable findings only, same scanner, same base image:

| | total | critical | high |
|---|---|---|---|
| before | 81 | 2 | 35 |
| after | **20** | **0** | **8** |

The 61 that disappear: 29 in `axios`, 7 in `node-forge`, 4 in `js-yaml`, the rest in their transitive trees. What remains sits either in packages that cannot be lifted inside the current ranges (`qs`, `ip-address`, `undici`) or in the Node runtime itself — the latter is picked up by rebuilding on a current `node:24-slim`.

## Testing

`npm run build` passes. The built image starts and answers MCP `initialize` and `tools/list` with the **same 44 tools** as the published image, byte-identical tool names.

## Two things noticed while looking

- **A full `npm update` breaks the build.** It does lift `qs`, `ip-address` and `@modelcontextprotocol/sdk` (1.11.1 → 1.30.0), but `tsc` then exhausts the 4 GB V8 heap during `npm run build` and aborts with SIGABRT. That looks like a type-graph blowup in the newer SDK rather than anything in this repository, so it is deliberately **not** part of this PR — flagging it in case you want to pursue the SDK bump separately.
- **`typescript` is declared under `dependencies`,** not `devDependencies`, so it survives the prune. It carries no advisories, so this PR leaves it alone — but moving it would shrink the image further.

## Context

I run this server in a Kubernetes homelab and pin the image by digest. Happy to split this into two PRs (Dockerfile / lockfile) if you prefer them separate, or to rebase in whichever order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production deployments now exclude development-only tooling, resulting in leaner runtime packages and potentially smaller container images.
  * Updated networking support to a newer version for improved maintenance and compatibility.
  * Reduced security findings in the resulting container image, including eliminating critical findings.
  * Updated release metadata to reflect the production image optimization and dependency maintenance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->