### PR TITLE
fix(ci): publish semver Docker tags via metadata-action's native value= (#139)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set semver and latest tags if release
+      - name: Set latest tag if release
         id: tagmeta
         run: |
           if [ "${{ github.event_name }}" = "workflow_call" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -51,21 +51,22 @@ jobs:
           else
             echo "LATEST=" >> $GITHUB_OUTPUT
           fi
-
-          if [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "SEMVER=type=semver,pattern=${{ inputs.versionTag }}" >> $GITHUB_OUTPUT
-          else
-            echo "SEMVER=" >> $GITHUB_OUTPUT
-          fi
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # docker-publish.yml is invoked via workflow_call from a push to main,
+          # so github.ref here is refs/heads/main, never a tag ref - type=semver's
+          # own git-tag detection never sees a version. Pass the published version
+          # explicitly via `value=` instead (metadata-action's documented override
+          # for non-tag-ref contexts) rather than relying on pattern to parse it.
           tags: |
             type=ref,event=pr
             type=sha
-            ${{ steps.tagmeta.outputs.SEMVER }}
+            type=semver,pattern={{version}},value=${{ inputs.versionTag }},enable=${{ inputs.versionTag != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.versionTag }},enable=${{ inputs.versionTag != '' }}
+            type=semver,pattern={{major}},value=${{ inputs.versionTag }},enable=${{ inputs.versionTag != '' }}
             ${{ steps.tagmeta.outputs.LATEST }}
       - name: Build (linux/amd64) for smoke test
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,11 +56,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
-          # docker-publish.yml is invoked via workflow_call from a push to main,
-          # so github.ref here is refs/heads/main, never a tag ref - type=semver's
-          # own git-tag detection never sees a version. Pass the published version
-          # explicitly via `value=` instead (metadata-action's documented override
-          # for non-tag-ref contexts) rather than relying on pattern to parse it.
+          # value= is required: this job runs via workflow_call, so github.ref is
+          # never a tag ref for type=semver's built-in git-tag detection to find.
           tags: |
             type=ref,event=pr
             type=sha


### PR DESCRIPTION
Fixes #139: `ghcr.io/baruchiro/paperless-mcp` now gets semver Docker tags (`<version>`, `<major>.<minor>`, `<major>`) alongside `latest`, instead of only `latest`/`sha-<commit>`.

Closes #141: that PR tried to fix the same issue with a hand-rolled bash script (heredoc + `case` statement) to derive the tags, reimplementing logic `docker/metadata-action` already provides (major/minor derivation, prerelease handling). It also assumed a git tag existing was enough for `type=semver` to pick it up — but `docker-publish.yml` runs via `workflow_call` from a push to `main`, so `github.ref` there is always `refs/heads/main`, never a tag ref, and `type=semver`'s git-tag detection has nothing to parse regardless of whether a tag exists elsewhere in the repo.

## Fix

docker-publish.yml runs as a workflow_call from a push to main, so
github.ref is refs/heads/main there - never a tag ref - which means
type=semver's own git-tag detection has nothing to parse, and pattern
alone can't carry a literal version. Pass the published version
through metadata-action's documented `value=` override instead of a
hand-rolled shell script for tag derivation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image tagging to generate version, major-minor, and major tags when a version is provided.
  - Preserved latest-tag handling separately from semantic version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KKNKsRdUHQY7STjNNHyxF