### PR TITLE
fix(schema): migrate to Zod v4 and SDK 1.30 to clear the remaining array-form types

### DIFF
--- a/.changeset/zod-v4-sdk-1-30.md
+++ b/.changeset/zod-v4-sdk-1-30.md
@@ -1,0 +1,17 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+fix(schema): finish #138 by moving to Zod v4, so no tool advertises an array-valued `type`
+
+Strict MCP clients and gateways reject an array-valued `type` (`"type": ["string", "null"]`) and silently drop the whole tool. The remaining occurrences after the previous fix were the mail-rule fields the API declares with no constraint to carry — `filter_attachment_filename_include`, `filter_attachment_filename_exclude`, `action_parameter` — and `query_documents`' `paperless_filters`, none of which could be fixed by declaring constraints.
+
+They came from `zod-to-json-schema`, which the MCP SDK uses for Zod v3 shapes and which collapses any union of unchecked primitives into that form. No SDK release changes this: 1.11.1 through 1.30.0 emit byte-identical schemas for a v3 shape. The SDK does convert `zod/v4` shapes with Zod's own `toJSONSchema`, which emits `anyOf` instead, so the server now uses Zod v4 with `@modelcontextprotocol/sdk` at ^1.30.0 (1.23.0 is the first release that reads v4 shapes; earlier ones drop them from the advertised schema). `zod` is pinned to `~4.4.3` because 4.5.0 reintroduced the collapse.
+
+Alongside the bump:
+
+- `matching_algorithm` on tags, correspondents and document types is now advertised as the integer enum the OpenAPI spec declares (`enum: [0, 1, 2, 3, 4, 5, 6]`) instead of a 0-6 range, and is built from the shared option map so the two cannot drift.
+- `Document.storage_path` and `Document.archive_serial_number` are typed `number | null`, matching the spec, which declares both as nullable integers. They were typed `string | null`.
+- Tool schemas no longer carry `additionalProperties: false` at the top level. It was never enforced — unknown properties were stripped, not rejected — so the schemas now describe what the server actually does. Nested objects declared `.strict()`, such as `bulk_edit_documents`' `set_permissions`, still advertise and enforce it.
+
+This also fixes a `tsc` out-of-memory crash: SDK 1.23.0 and later paired with Zod 3.25.x hits an unbounded type instantiation (modelcontextprotocol/typescript-sdk#1180) that exhausts the heap even at 8GB, which is why the SDK could not be upgraded on its own.

--- a/.changeset/zod-v4-sdk-1-30.md
+++ b/.changeset/zod-v4-sdk-1-30.md
@@ -10,7 +10,7 @@ They came from `zod-to-json-schema`, which the MCP SDK uses for Zod v3 shapes an
 
 Alongside the bump:
 
-- `matching_algorithm` on tags, correspondents and document types is now advertised as the integer enum the OpenAPI spec declares (`enum: [0, 1, 2, 3, 4, 5, 6]`) instead of a 0-6 range, and is built from the shared option map so the two cannot drift.
+- `matching_algorithm` on tags, correspondents and document types is declared once and narrows to `MatchingAlgorithm` after its range check, so the API request types take it without a cast. The advertised schema is unchanged.
 - `Document.storage_path` and `Document.archive_serial_number` are typed `number | null`, matching the spec, which declares both as nullable integers. They were typed `string | null`.
 - Tool schemas no longer carry `additionalProperties: false` at the top level. It was never enforced — unknown properties were stripped, not rejected — so the schemas now describe what the server actually does. Nested objects declared `.strict()`, such as `bulk_edit_documents`' `set_permissions`, still advertise and enforce it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,12 +179,12 @@ When creating or modifying tools, clearly distinguish:
 ## Dependencies
 
 ### Production Dependencies
-- `@modelcontextprotocol/sdk` (^1.11.1) - MCP server implementation
+- `@modelcontextprotocol/sdk` (^1.30.0) - MCP server implementation. 1.23.0 is the minimum that reads `zod/v4` shapes; below it they are silently dropped from the advertised `inputSchema`.
 - `axios` (^1.9.0) - HTTP client for API requests
 - `express` (^5.1.0) - HTTP server for HTTP transport mode
 - `form-data` (^4.0.2) - Multipart form data for file uploads
 - `typescript` (^5.8.3) - TypeScript compiler (Note: Listed as production dependency in this project)
-- `zod` (^3.24.1) - Schema validation
+- `zod` (~4.4.3) - Schema validation. **The pin is deliberate, do not widen it.** On the v4 path the SDK converts schemas with zod's own `toJSONSchema`, which emits `anyOf` for a nullable or union field; from 4.5.0 on it went back to collapsing unchecked ones into `"type": ["string", "null"]`, which strict MCP clients reject by dropping the whole tool (#138). `src/tools/schemaCompat.test.ts` fails if that form reappears.
 
 ### Development Dependencies
 - `@anthropic-ai/dxt` (^0.2.6) - Distribution packaging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@baruchiro/paperless-mcp",
-  "version": "0.5.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baruchiro/paperless-mcp",
-      "version": "0.5.1",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.1",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.9.0",
         "express": "^5.1.0",
         "form-data": "^4.0.2",
         "typescript": "^5.8.3",
-        "zod": "^3.24.1"
+        "zod": "~4.4.3"
       },
       "bin": {
         "paperless-mcp": "build/index.js"
@@ -58,6 +58,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/@anthropic-ai/dxt/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@babel/runtime": {
@@ -305,6 +315,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -637,23 +659,43 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-      "integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -865,6 +907,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -967,22 +1042,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/braces": {
@@ -1021,6 +1114,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1171,9 +1265,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1365,17 +1460,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -1406,9 +1503,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1416,7 +1518,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/extendable-error": {
@@ -1451,6 +1553,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1466,6 +1574,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -1839,19 +1963,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-id": {
@@ -1864,14 +2002,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -1887,6 +2030,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1967,6 +2119,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -1979,6 +2140,18 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2022,11 +2195,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2135,6 +2313,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2365,11 +2544,13 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2423,17 +2604,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/read-yaml-file": {
@@ -2449,6 +2631,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2604,13 +2795,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2622,12 +2814,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2640,6 +2833,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2657,6 +2851,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -2709,9 +2904,10 @@
       "dev": true
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2853,16 +3049,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2972,20 +3186,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "url": "https://github.com/baruchiro/paperless-mcp/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.9.0",
     "express": "^5.1.0",
     "form-data": "^4.0.2",
     "typescript": "^5.8.3",
-    "zod": "^3.24.1"
+    "zod": "~4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/dxt": "^0.2.6",

--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -109,7 +109,7 @@ export class PaperlessAPI {
   async postDocument(
     document: Buffer,
     filename: string,
-    metadata: Record<string, string | string[] | number | number[]> = {}
+    metadata: Record<string, string | string[] | number | number[] | undefined> = {}
   ): Promise<string> {
     const formData = new FormData();
     formData.append("document", document, { filename });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,7 +84,7 @@ export interface Document {
   id: number;
   correspondent: number | null;
   document_type: number | null;
-  storage_path: string | null;
+  storage_path: number | null;
   title: string;
   content: string | null;
   tags: number[];
@@ -93,7 +93,7 @@ export interface Document {
   modified: string;
   added: string;
   deleted_at: string | null;
-  archive_serial_number: string | null;
+  archive_serial_number: number | null;
   original_file_name: string;
   archived_file_name: string;
   owner: number | null;

--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -1,11 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 import { PaperlessAPI } from "../api/PaperlessAPI";
-import { MATCHING_ALGORITHM_DESCRIPTION } from "../api/types";
 import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { matchingAlgorithmSchema } from "./utils/matchingAlgorithm";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -68,13 +68,7 @@ export function registerCorrespondentTools(
     {
       name: z.string(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -95,13 +89,7 @@ export function registerCorrespondentTools(
       id: z.number(),
       name: z.string(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/customFields.ts
+++ b/src/tools/customFields.ts
@@ -17,7 +17,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
-    withErrorHandling(async (args = {}) => {
+    withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
       const response = await api.request(
@@ -63,7 +63,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
         "documentlink",
         "select",
       ]),
-      extra_data: z.record(z.unknown()).nullable().optional(),
+      extra_data: z.record(z.string(), z.unknown()).nullable().optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -93,7 +93,7 @@ export function registerCustomFieldTools(server: McpServer, api: PaperlessAPI) {
           "select",
         ])
         .optional(),
-      extra_data: z.record(z.unknown()).nullable().optional(),
+      extra_data: z.record(z.string(), z.unknown()).nullable().optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -1,11 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 import { PaperlessAPI } from "../api/PaperlessAPI";
-import { MATCHING_ALGORITHM_DESCRIPTION } from "../api/types";
 import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { matchingAlgorithmSchema } from "./utils/matchingAlgorithm";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -25,7 +25,7 @@ export function registerDocumentTypeTools(
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
-    withErrorHandling(async (args = {}, extra) => {
+    withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
       const response = await api.request(
@@ -68,13 +68,7 @@ export function registerDocumentTypeTools(
     {
       name: z.string(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -93,13 +87,7 @@ export function registerDocumentTypeTools(
       id: z.number(),
       name: z.string(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -365,7 +365,7 @@ export function registerDocumentTools(server: McpServer, api: PaperlessAPI) {
 
       const validationResult = postDocumentSchema.safeParse(args);
       if (!validationResult.success) {
-        throw new Error(validationResult.error.errors.map(e => e.message).join("; "));
+        throw new Error(validationResult.error.issues.map(e => e.message).join("; "));
       }
 
       let document: Buffer;

--- a/src/tools/mail.ts
+++ b/src/tools/mail.ts
@@ -88,7 +88,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       page: z.number().optional(),
       page_size: z.number().optional(),
     },
-    withErrorHandling(async (args = {}) => {
+    withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
       const response = await api.getMailAccounts(queryString);
@@ -142,7 +142,7 @@ export function registerMailTools(server: McpServer, api: PaperlessAPI) {
       page: z.number().optional(),
       page_size: z.number().optional(),
     },
-    withErrorHandling(async (args = {}) => {
+    withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
       const response = await api.getMailRules(queryString);

--- a/src/tools/schemaCompat.test.ts
+++ b/src/tools/schemaCompat.test.ts
@@ -5,23 +5,12 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer } from "../server";
 
 // Strict MCP clients and gateways reject an array-valued `type` and silently drop
-// the whole tool (#138). zod-to-json-schema emits that form for any union of
-// unchecked primitives, so a new `z.string().nullable()` on any tool brings the
-// bug back with no visible symptom. This walks every advertised schema instead of
-// a field list, so a new occurrence anywhere fails the build.
-//
-// The entries below are the occurrences still outstanding, waiting on the Zod v4
-// migration. The assertion is an exact match, so fixing one fails here too: the
-// list may only shrink, and reaches zero when that migration lands.
-const KNOWN_ARRAY_FORM_TYPES = [
-  'create_mail_rule .properties.action_parameter.type = ["string","null"]',
-  'create_mail_rule .properties.filter_attachment_filename_exclude.type = ["string","null"]',
-  'create_mail_rule .properties.filter_attachment_filename_include.type = ["string","null"]',
-  'query_documents .properties.paperless_filters.additionalProperties.anyOf[0].type = ["string","number","boolean"]',
-  'update_mail_rule .properties.action_parameter.type = ["string","null"]',
-  'update_mail_rule .properties.filter_attachment_filename_exclude.type = ["string","null"]',
-  'update_mail_rule .properties.filter_attachment_filename_include.type = ["string","null"]',
-];
+// the whole tool (#138). A JSON Schema converter reaches that form by collapsing a
+// union of unchecked primitives: `zod-to-json-schema` (the zod v3 path) always does
+// it, and zod's own converter did it again from 4.5.0 on. The tools are only free
+// of it because the server is on the zod v4 path with zod pinned to 4.4.x, so this
+// walks every advertised schema rather than a field list: bumping that pin, moving
+// off zod v4, or adding a construct that reintroduces the form fails here.
 
 function arrayFormTypes(node: unknown, path = ""): string[] {
   if (Array.isArray(node)) {
@@ -37,7 +26,7 @@ function arrayFormTypes(node: unknown, path = ""): string[] {
   );
 }
 
-test("no tool advertises an array-form `type` beyond the known-outstanding set (#138)", async () => {
+test("no tool advertises an array-form `type` (#138)", async () => {
   const server = createMcpServer({
     baseUrl: "http://paperless.test",
     token: "test-token",
@@ -56,7 +45,7 @@ test("no tool advertises an array-form `type` beyond the known-outstanding set (
       )
       .sort();
 
-    assert.deepEqual(found, [...KNOWN_ARRAY_FORM_TYPES].sort());
+    assert.deepEqual(found, []);
   } finally {
     await client.close();
     await server.close();

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,11 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 import { PaperlessAPI } from "../api/PaperlessAPI";
-import { MATCHING_ALGORITHM_DESCRIPTION } from "../api/types";
 import {
   enhanceMatchingAlgorithm,
   enhanceMatchingAlgorithmArray,
 } from "../api/utils";
+import { matchingAlgorithmSchema } from "./utils/matchingAlgorithm";
 import { withErrorHandling } from "./utils/middlewares";
 import { buildQueryString } from "./utils/queryString";
 
@@ -22,7 +22,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
       name__istartswith: z.string().optional(),
       ordering: z.string().optional(),
     },
-    withErrorHandling(async (args = {}) => {
+    withErrorHandling(async (args) => {
       if (!api) throw new Error("Please configure API connection first");
       const queryString = buildQueryString(args);
       const tagsResponse = await api.request(
@@ -55,13 +55,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .regex(/^#[0-9A-Fa-f]{6}$/)
         .optional(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -89,13 +83,7 @@ export function registerTagTools(server: McpServer, api: PaperlessAPI) {
         .regex(/^#[0-9A-Fa-f]{6}$/)
         .optional(),
       match: z.string().optional(),
-      matching_algorithm: z
-        .number()
-        .int()
-        .min(0)
-        .max(6)
-        .optional()
-        .describe(MATCHING_ALGORITHM_DESCRIPTION),
+      matching_algorithm: matchingAlgorithmSchema.optional(),
     },
     withErrorHandling(async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/utils/documentQuery.ts
+++ b/src/tools/utils/documentQuery.ts
@@ -108,7 +108,7 @@ export const paperlessFilterValueSchema = z.union([
   z.array(paperlessFilterScalarSchema),
 ]);
 
-export const paperlessFiltersSchema = z.record(paperlessFilterValueSchema);
+export const paperlessFiltersSchema = z.record(z.string(), paperlessFilterValueSchema);
 
 const DOCUMENT_QUERY_BASE_ARGS_SHAPE = {
   page: z.number().optional(),

--- a/src/tools/utils/matchingAlgorithm.ts
+++ b/src/tools/utils/matchingAlgorithm.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import {
+  MATCHING_ALGORITHM_DESCRIPTION,
+  MATCHING_ALGORITHM_OPTIONS,
+  MatchingAlgorithm,
+} from "../../api/types";
+
+const MATCHING_ALGORITHM_VALUES = Object.keys(MATCHING_ALGORITHM_OPTIONS).map(
+  Number
+) as MatchingAlgorithm[];
+
+// `MatchingAlgorithm` in the OpenAPI spec is an integer enum, so the schema is
+// built from the option map rather than a 0-6 range: that keeps the advertised
+// values in step with the map and infers `MatchingAlgorithm` instead of `number`,
+// which is what the PaperlessAPI request types require.
+export const matchingAlgorithmSchema = z
+  .literal(MATCHING_ALGORITHM_VALUES)
+  .describe(MATCHING_ALGORITHM_DESCRIPTION);

--- a/src/tools/utils/matchingAlgorithm.ts
+++ b/src/tools/utils/matchingAlgorithm.ts
@@ -1,18 +1,16 @@
 import { z } from "zod";
 import {
   MATCHING_ALGORITHM_DESCRIPTION,
-  MATCHING_ALGORITHM_OPTIONS,
   MatchingAlgorithm,
 } from "../../api/types";
 
-const MATCHING_ALGORITHM_VALUES = Object.keys(MATCHING_ALGORITHM_OPTIONS).map(
-  Number
-) as MatchingAlgorithm[];
-
-// `MatchingAlgorithm` in the OpenAPI spec is an integer enum, so the schema is
-// built from the option map rather than a 0-6 range: that keeps the advertised
-// values in step with the map and infers `MatchingAlgorithm` instead of `number`,
-// which is what the PaperlessAPI request types require.
+// The 0-6 range the API declares is exactly the set `MatchingAlgorithm`
+// enumerates, so narrowing to it after the check lets the PaperlessAPI request
+// types take the parsed value without a cast at every call site.
 export const matchingAlgorithmSchema = z
-  .literal(MATCHING_ALGORITHM_VALUES)
+  .number()
+  .int()
+  .min(0)
+  .max(6)
+  .transform((value) => value as MatchingAlgorithm)
   .describe(MATCHING_ALGORITHM_DESCRIPTION);


### PR DESCRIPTION
Closes #138

Follow-up to #146, which fixed #138 for every field that had an OpenAPI constraint to declare. This clears the rest.

## The problem

Strict MCP clients and gateways reject an array-valued `type` (`"type": ["string", "null"]`) and silently drop the whole tool. After #146, seven occurrences remained across three tools — `create_mail_rule`, `update_mail_rule` and `query_documents` — on fields the spec constrains in no way, so there was nothing to declare that would stop the collapse.

## Why the SDK bump alone does nothing

The form comes from `zod-to-json-schema`, which the SDK uses for Zod **v3** shapes, and which collapses any union of unchecked primitives into it. I checked every SDK release: **1.11.1 through 1.30.0 emit byte-identical schemas for a v3 shape**, and there is no public hook to override `inputSchema` (upstream [#283](https://github.com/modelcontextprotocol/typescript-sdk/issues/283) defers it to v2's `fromJsonSchema()`).

The SDK *does* convert `zod/v4` shapes with Zod's own `toJSONSchema`, which emits `anyOf`. That is the only native escape, and it needs SDK ≥ 1.23.0 — below that, v4 shapes are silently dropped from the advertised schema entirely.

## Why this also fixes the `tsc` OOM

SDK ≥ 1.23.0 paired with Zod 3.25.x hits an unbounded type instantiation ([typescript-sdk#1180](https://github.com/modelcontextprotocol/typescript-sdk/issues/1180)) that exhausts the heap — I tried 4GB and 8GB, both died. That is why the SDK could not be upgraded on its own. On real Zod 4, `npm run build` completes in **2.5 seconds**.

## The Zod pin is load-bearing

`zod` is pinned to `~4.4.3`, not `^4`. I verified against 4.5.4: it **reintroduces** the collapse for check-less nullables and unions, while a *checked* one still emits `anyOf` — the exact same rule `zod-to-json-schema` follows.

```
zod 4.4.3  z.string().nullable()             -> {"anyOf":[{"type":"string"},{"type":"null"}]}
zod 4.5.4  z.string().nullable()             -> {"type":["string","null"]}          <- #138 is back
zod 4.5.4  z.string().max(256).nullable()    -> {"anyOf":[...]}                     <- still fine
```

`src/tools/schemaCompat.test.ts` (added in #146) now asserts the empty set, so it is the tripwire that catches anyone widening that pin. The reason is also written into CLAUDE.md next to the dependency.

## Type errors this surfaced

With Zod v3 the args type resolved loosely enough that mismatches never surfaced; SDK 1.30's `ShapeOutput` types them precisely and 18 errors fell out across 7 files. Each change below is one the compiler required — I checked by reverting them individually:

- **`Document.storage_path` and `Document.archive_serial_number` were typed `string | null`.** The spec declares both as nullable **integers**. Now `number | null`.
- **`matching_algorithm`** is declared once in `src/tools/utils/matchingAlgorithm.ts` and narrows to `MatchingAlgorithm` after the same 0-6 range check, so the API request types take it without a cast at six call sites. **The advertised schema is unchanged.**
- **`postDocument`'s metadata** admits `undefined` values, which every caller already passed and the method body already guards.
- Mechanical: `z.record` takes an explicit key schema, `ZodError` exposes `.issues`, and the `args = {}` defaults are gone — I confirmed against the SDK that a call whose arguments fail to parse never reaches the handler, so they were unreachable.

## Verification

I diffed all 44 tools' advertised schemas before and after, through a real client over the in-memory transport. **Every remaining difference is forced by the converter swap; none is an authored change to the tool surface.**

- **All 7 array-form occurrences are gone.** Same 44 tools, identical descriptions, identical `required` sets.
- Top-level `additionalProperties: false` is gone from every tool — Zod v4 emits it only for `.strict()` objects. It was never enforced anyway (unknown keys were stripped, not rejected), so the schemas now describe what the server actually does. Nested `.strict()` objects, such as `bulk_edit_documents`' `set_permissions`, still advertise **and** enforce it; I checked that one specifically, given the comment explaining why it is strict.
- Every `z.number().int()` gains `±9007199254740991` bounds — Zod v4's safe-integer range.
- `query_documents` loses a self-referencing `$ref` that some clients cannot resolve; it is inlined now.
- `npm run build` clean, `npm test` 57/57, both e2e suites green against Paperless 2.x and 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KKNKsRdUHQY7STjNNHyxF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tool schemas that advertised unsupported array-valued types, improving compatibility with strict MCP clients and gateways.
  - Corrected document metadata types for storage paths and archive serial numbers.
  - Improved document upload handling when metadata fields are undefined.

- **Compatibility**
  - Updated schema validation to produce standards-compatible nullable and union fields.
  - Standardized matching-algorithm validation across relevant tools.
  - Removed misleading rejection behavior for unknown tool properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->