### PR TITLE
feat(http): add opt-in --stateful Streamable HTTP transport

### DIFF
--- a/.changeset/stateful-http-transport.md
+++ b/.changeset/stateful-http-transport.md
@@ -1,0 +1,9 @@
+---
+"@baruchiro/paperless-mcp": minor
+---
+
+Add an opt-in `--stateful` Streamable HTTP transport
+
+The default HTTP mode stays stateless (a fresh transport + server per POST). `--stateful` keeps one transport and `McpServer` per `Mcp-Session-Id`, which is what clients that negotiate the 2025-11-25 protocol — notably MCP gateways — require: a persistent session plus a server→client notification stream, rather than a server that answers `GET /mcp` with 405.
+
+Sessions are bounded so an abandoned one (a client that never sends `DELETE /mcp`) can't leak its transport for the process lifetime — an unauthenticated memory-exhaustion vector under `--no-auth`. `HttpSessionStore` caps concurrent sessions (`--max-sessions`, default 256; new sessions get a 503 at the cap) and reaps sessions idle beyond `--session-timeout` (default 30m) on an interval.

--- a/src/http/httpSessionStore.test.ts
+++ b/src/http/httpSessionStore.test.ts
@@ -56,7 +56,7 @@ test("get returns undefined for an unknown session", () => {
   assert.equal(store.get("missing"), undefined);
 });
 
-test("sweepIdle closes and evicts only sessions past the timeout", () => {
+test("sweepIdle closes and evicts only sessions past the timeout", async () => {
   const clock = fakeClock();
   const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 100, now: clock.now });
   const stale = fakeTransport();
@@ -68,10 +68,12 @@ test("sweepIdle closes and evicts only sessions past the timeout", () => {
 
   const evicted = store.sweepIdle(); // cutoff = 150 - 100 = 50
   assert.deepEqual(evicted, ["stale"]);
+  assert.equal(store.size, 1, "eviction from the map is synchronous");
+  assert.equal(store.get("stale"), undefined, "stale session evicted");
+
+  await new Promise((resolve) => setImmediate(resolve)); // close() is deferred
   assert.equal(stale.closed, 1, "stale transport was closed");
   assert.equal(fresh.closed, 0, "fresh transport untouched");
-  assert.equal(store.size, 1);
-  assert.equal(store.get("stale"), undefined, "stale session evicted");
 });
 
 test("delete is a no-op for an unknown session", () => {
@@ -81,11 +83,53 @@ test("delete is a no-op for an unknown session", () => {
   assert.equal(store.size, 1);
 });
 
-test("startSweeper is idempotent and stopSweeper clears it", () => {
-  const store = new HttpSessionStore<FakeTransport>({ sweepIntervalMs: 10_000 });
+test("register rejects a new session at the cap and retains nothing", () => {
+  const store = new HttpSessionStore<FakeTransport>({ maxSessions: 1 });
+  assert.equal(store.register("a", fakeTransport()), true);
+
+  const rejected = fakeTransport();
+  assert.equal(store.register("b", rejected), false, "new id rejected at cap");
+  assert.equal(store.size, 1);
+  assert.equal(store.get("b"), undefined, "rejected session not stored");
+
+  // Re-registering an existing id is an update, allowed even at the cap.
+  assert.equal(store.register("a", fakeTransport()), true);
+  assert.equal(store.size, 1);
+});
+
+test("sweepIdle routes a rejecting close() to onSweepError, no unhandled rejection", async () => {
+  const clock = fakeClock();
+  const errors: unknown[] = [];
+  const store = new HttpSessionStore<ClosableTransport>({
+    idleTimeoutMs: 10,
+    now: clock.now,
+    onSweepError: (e) => errors.push(e),
+  });
+  store.register("a", { close: () => Promise.reject(new Error("boom")) });
+
+  clock.advance(20);
+  assert.deepEqual(store.sweepIdle(), ["a"], "evicted despite failing close");
+  assert.equal(store.size, 0);
+
+  await new Promise((resolve) => setImmediate(resolve)); // let the rejection settle
+  assert.equal(errors.length, 1, "close rejection captured");
+  assert.match(String((errors[0] as Error).message), /boom/);
+});
+
+test("startSweeper schedules one recurring sweep; stopSweeper halts it", (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  const store = new HttpSessionStore<FakeTransport>({ sweepIntervalMs: 1000 });
+  const sweep = t.mock.method(store, "sweepIdle");
+
   store.startSweeper();
-  store.startSweeper(); // must not throw or double-schedule
+  store.startSweeper(); // idempotent: must not schedule a second interval
+
+  t.mock.timers.tick(1000);
+  assert.equal(sweep.mock.callCount(), 1, "one sweep per interval despite double start");
+  t.mock.timers.tick(1000);
+  assert.equal(sweep.mock.callCount(), 2);
+
   store.stopSweeper();
-  store.stopSweeper(); // safe to call when already stopped
-  assert.ok(true);
+  t.mock.timers.tick(5000);
+  assert.equal(sweep.mock.callCount(), 2, "no sweeps after stop");
 });

--- a/src/http/httpSessionStore.test.ts
+++ b/src/http/httpSessionStore.test.ts
@@ -4,51 +4,34 @@ import { HttpSessionStore, ClosableTransport } from "./httpSessionStore";
 
 type FakeTransport = ClosableTransport & { closed: number };
 
-/** Fake transport that records close() calls. */
-function fakeTransport(): FakeTransport {
-  return {
-    closed: 0,
-    close() {
-      this.closed += 1;
-    },
-  };
-}
-
-/** Controllable clock so idle behaviour is deterministic. */
-function fakeClock(start = 0) {
-  let t = start;
-  return {
-    now: () => t,
-    advance: (ms: number) => {
-      t += ms;
-    },
-  };
-}
-
 test("canCreate enforces the concurrent-session cap", () => {
   const store = new HttpSessionStore<FakeTransport>({ maxSessions: 2 });
   assert.equal(store.canCreate(), true);
-  store.register("a", fakeTransport());
+  store.register("a", { closed: 0, close() { this.closed += 1; } });
   assert.equal(store.canCreate(), true);
-  store.register("b", fakeTransport());
-  assert.equal(store.canCreate(), false, "cap reached");
+  store.register("b", { closed: 0, close() { this.closed += 1; } });
+  assert.equal(store.canCreate(), false);
   store.delete("a");
-  assert.equal(store.canCreate(), true, "freed a slot");
+  assert.equal(store.canCreate(), true);
 });
 
-test("get returns the transport and bumps activity", () => {
-  const clock = fakeClock();
-  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 100, now: clock.now });
-  const t = fakeTransport();
-  store.register("a", t);
+test("register rejects a new session at the cap and retains nothing", () => {
+  const store = new HttpSessionStore<FakeTransport>({ maxSessions: 1 });
+  assert.equal(store.register("a", { closed: 0, close() { this.closed += 1; } }), true);
 
-  clock.advance(90);
-  assert.equal(store.get("a"), t, "returns the registered transport");
+  assert.equal(store.register("b", { closed: 0, close() { this.closed += 1; } }), false);
+  assert.equal(store.size, 1);
+  assert.equal(store.get("b"), undefined);
 
-  // Activity was bumped at t=90, so at t=180 (90ms later) it is still fresh.
-  clock.advance(90);
-  assert.deepEqual(store.sweepIdle(), [], "recently-used session survives");
-  assert.equal(t.closed, 0);
+  assert.equal(store.register("a", { closed: 0, close() { this.closed += 1; } }), true);
+  assert.equal(store.size, 1);
+});
+
+test("get returns the registered transport", () => {
+  const store = new HttpSessionStore<FakeTransport>();
+  const transport: FakeTransport = { closed: 0, close() { this.closed += 1; } };
+  store.register("a", transport);
+  assert.equal(store.get("a"), transport);
 });
 
 test("get returns undefined for an unknown session", () => {
@@ -56,80 +39,67 @@ test("get returns undefined for an unknown session", () => {
   assert.equal(store.get("missing"), undefined);
 });
 
-test("sweepIdle closes and evicts only sessions past the timeout", async () => {
-  const clock = fakeClock();
-  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 100, now: clock.now });
-  const stale = fakeTransport();
-  const fresh = fakeTransport();
-  store.register("stale", stale);
-
-  clock.advance(150); // "stale" is now 150ms idle
-  store.register("fresh", fresh); // registered at t=150
-
-  const evicted = store.sweepIdle(); // cutoff = 150 - 100 = 50
-  assert.deepEqual(evicted, ["stale"]);
-  assert.equal(store.size, 1, "eviction from the map is synchronous");
-  assert.equal(store.get("stale"), undefined, "stale session evicted");
-
-  await new Promise((resolve) => setImmediate(resolve)); // close() is deferred
-  assert.equal(stale.closed, 1, "stale transport was closed");
-  assert.equal(fresh.closed, 0, "fresh transport untouched");
-});
-
 test("delete is a no-op for an unknown session", () => {
   const store = new HttpSessionStore<FakeTransport>();
-  store.register("a", fakeTransport());
+  store.register("a", { closed: 0, close() { this.closed += 1; } });
   store.delete("nope");
   assert.equal(store.size, 1);
 });
 
-test("register rejects a new session at the cap and retains nothing", () => {
-  const store = new HttpSessionStore<FakeTransport>({ maxSessions: 1 });
-  assert.equal(store.register("a", fakeTransport()), true);
-
-  const rejected = fakeTransport();
-  assert.equal(store.register("b", rejected), false, "new id rejected at cap");
+test("sweepIdle keeps a session still within its timeout", () => {
+  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 60_000 });
+  const transport: FakeTransport = { closed: 0, close() { this.closed += 1; } };
+  store.register("a", transport);
+  assert.deepEqual(store.sweepIdle(), []);
   assert.equal(store.size, 1);
-  assert.equal(store.get("b"), undefined, "rejected session not stored");
-
-  // Re-registering an existing id is an update, allowed even at the cap.
-  assert.equal(store.register("a", fakeTransport()), true);
-  assert.equal(store.size, 1);
+  assert.equal(transport.closed, 0);
 });
 
-test("sweepIdle routes a rejecting close() to onSweepError, no unhandled rejection", async () => {
-  const clock = fakeClock();
-  const errors: unknown[] = [];
-  const store = new HttpSessionStore<ClosableTransport>({
-    idleTimeoutMs: 10,
-    now: clock.now,
-    onSweepError: (e) => errors.push(e),
-  });
-  store.register("a", { close: () => Promise.reject(new Error("boom")) });
+test("sweepIdle evicts and closes a session past its timeout", async () => {
+  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 0 });
+  const transport: FakeTransport = { closed: 0, close() { this.closed += 1; } };
+  store.register("a", transport);
 
-  clock.advance(20);
-  assert.deepEqual(store.sweepIdle(), ["a"], "evicted despite failing close");
-  assert.equal(store.size, 0);
+  assert.deepEqual(store.sweepIdle(), ["a"]);
+  assert.equal(store.size, 0, "eviction from the map is synchronous");
+  assert.equal(store.get("a"), undefined);
 
-  await new Promise((resolve) => setImmediate(resolve)); // let the rejection settle
-  assert.equal(errors.length, 1, "close rejection captured");
-  assert.match(String((errors[0] as Error).message), /boom/);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(transport.closed, 1, "transport closed after the deferred close settles");
 });
 
-test("startSweeper schedules one recurring sweep; stopSweeper halts it", (t) => {
-  t.mock.timers.enable({ apis: ["setInterval"] });
-  const store = new HttpSessionStore<FakeTransport>({ sweepIntervalMs: 1000 });
-  const sweep = t.mock.method(store, "sweepIdle");
+test("sweepIdle evicts a session whose close() rejects, without an unhandled rejection", async () => {
+  const store = new HttpSessionStore<ClosableTransport>({ idleTimeoutMs: 0 });
+  const original = console.error;
+  const logged: unknown[][] = [];
+  console.error = (...args: unknown[]) => { logged.push(args); };
+  try {
+    store.register("a", { close: () => Promise.reject(new Error("boom")) });
+    assert.deepEqual(store.sweepIdle(), ["a"]);
+    assert.equal(store.size, 0);
 
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(logged.length, 1, "the rejection was caught and logged");
+    assert.match(String(logged[0][1]), /boom/);
+  } finally {
+    console.error = original;
+  }
+});
+
+test("startSweeper reaps idle sessions until stopSweeper halts it", async () => {
+  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 0 });
+  const first: FakeTransport = { closed: 0, close() { this.closed += 1; } };
+  store.register("a", first);
   store.startSweeper();
-  store.startSweeper(); // idempotent: must not schedule a second interval
+  store.startSweeper(); // idempotent
 
-  t.mock.timers.tick(1000);
-  assert.equal(sweep.mock.callCount(), 1, "one sweep per interval despite double start");
-  t.mock.timers.tick(1000);
-  assert.equal(sweep.mock.callCount(), 2);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(store.size, 0, "the running sweeper reaped the idle session");
+  assert.equal(first.closed, 1);
 
   store.stopSweeper();
-  t.mock.timers.tick(5000);
-  assert.equal(sweep.mock.callCount(), 2, "no sweeps after stop");
+  const second: FakeTransport = { closed: 0, close() { this.closed += 1; } };
+  store.register("b", second);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(store.size, 1, "no sweeps after stopSweeper");
 });

--- a/src/http/httpSessionStore.test.ts
+++ b/src/http/httpSessionStore.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { HttpSessionStore, ClosableTransport } from "./httpSessionStore";
+
+type FakeTransport = ClosableTransport & { closed: number };
+
+/** Fake transport that records close() calls. */
+function fakeTransport(): FakeTransport {
+  return {
+    closed: 0,
+    close() {
+      this.closed += 1;
+    },
+  };
+}
+
+/** Controllable clock so idle behaviour is deterministic. */
+function fakeClock(start = 0) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+test("canCreate enforces the concurrent-session cap", () => {
+  const store = new HttpSessionStore<FakeTransport>({ maxSessions: 2 });
+  assert.equal(store.canCreate(), true);
+  store.register("a", fakeTransport());
+  assert.equal(store.canCreate(), true);
+  store.register("b", fakeTransport());
+  assert.equal(store.canCreate(), false, "cap reached");
+  store.delete("a");
+  assert.equal(store.canCreate(), true, "freed a slot");
+});
+
+test("get returns the transport and bumps activity", () => {
+  const clock = fakeClock();
+  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 100, now: clock.now });
+  const t = fakeTransport();
+  store.register("a", t);
+
+  clock.advance(90);
+  assert.equal(store.get("a"), t, "returns the registered transport");
+
+  // Activity was bumped at t=90, so at t=180 (90ms later) it is still fresh.
+  clock.advance(90);
+  assert.deepEqual(store.sweepIdle(), [], "recently-used session survives");
+  assert.equal(t.closed, 0);
+});
+
+test("get returns undefined for an unknown session", () => {
+  const store = new HttpSessionStore<FakeTransport>();
+  assert.equal(store.get("missing"), undefined);
+});
+
+test("sweepIdle closes and evicts only sessions past the timeout", () => {
+  const clock = fakeClock();
+  const store = new HttpSessionStore<FakeTransport>({ idleTimeoutMs: 100, now: clock.now });
+  const stale = fakeTransport();
+  const fresh = fakeTransport();
+  store.register("stale", stale);
+
+  clock.advance(150); // "stale" is now 150ms idle
+  store.register("fresh", fresh); // registered at t=150
+
+  const evicted = store.sweepIdle(); // cutoff = 150 - 100 = 50
+  assert.deepEqual(evicted, ["stale"]);
+  assert.equal(stale.closed, 1, "stale transport was closed");
+  assert.equal(fresh.closed, 0, "fresh transport untouched");
+  assert.equal(store.size, 1);
+  assert.equal(store.get("stale"), undefined, "stale session evicted");
+});
+
+test("delete is a no-op for an unknown session", () => {
+  const store = new HttpSessionStore<FakeTransport>();
+  store.register("a", fakeTransport());
+  store.delete("nope");
+  assert.equal(store.size, 1);
+});
+
+test("startSweeper is idempotent and stopSweeper clears it", () => {
+  const store = new HttpSessionStore<FakeTransport>({ sweepIntervalMs: 10_000 });
+  store.startSweeper();
+  store.startSweeper(); // must not throw or double-schedule
+  store.stopSweeper();
+  store.stopSweeper(); // safe to call when already stopped
+  assert.ok(true);
+});

--- a/src/http/httpSessionStore.ts
+++ b/src/http/httpSessionStore.ts
@@ -1,25 +1,14 @@
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
-/**
- * Minimal shape the store needs from a transport: something it can close when a
- * session is evicted. Kept as an interface so the store is unit-testable with a
- * fake transport (no real HTTP server required).
- */
+// An interface (not the concrete transport) so the store can be tested with a
+// stub that only implements close().
 export interface ClosableTransport {
   close(): void | Promise<void>;
 }
 
 export interface HttpSessionStoreOptions {
-  /** Hard cap on concurrent sessions; new initialize requests are rejected above it. */
   maxSessions?: number;
-  /** Sessions with no activity for this long (ms) are closed and evicted. */
   idleTimeoutMs?: number;
-  /** How often (ms) the idle sweep runs. Defaults to min(idleTimeoutMs, 60s). */
-  sweepIntervalMs?: number;
-  /** Injectable clock, for tests. */
-  now?: () => number;
-  /** Called when a transport's close() rejects during an idle sweep. Defaults to console.error. */
-  onSweepError?: (error: unknown) => void;
 }
 
 interface SessionEntry<T> {
@@ -44,71 +33,55 @@ export class HttpSessionStore<
   private readonly entries = new Map<string, SessionEntry<T>>();
   private readonly maxSessions: number;
   private readonly idleTimeoutMs: number;
-  private readonly sweepIntervalMs: number;
-  private readonly now: () => number;
-  private readonly onSweepError: (error: unknown) => void;
   private timer?: ReturnType<typeof setInterval>;
 
   constructor(options: HttpSessionStoreOptions = {}) {
     this.maxSessions = options.maxSessions ?? 256;
     this.idleTimeoutMs = options.idleTimeoutMs ?? 30 * 60 * 1000;
-    this.sweepIntervalMs =
-      options.sweepIntervalMs ?? Math.min(this.idleTimeoutMs, 60 * 1000);
-    this.now = options.now ?? Date.now;
-    this.onSweepError =
-      options.onSweepError ??
-      ((error) =>
-        console.error("[paperless-mcp] error closing idle session", error));
   }
 
   get size(): number {
     return this.entries.size;
   }
 
-  /** True when a new session may be created (concurrent cap not yet reached). */
   canCreate(): boolean {
     return this.entries.size < this.maxSessions;
   }
 
   /**
-   * Register a freshly-initialized session, stamping it active now. Returns
-   * false (and stores nothing) when the cap is already reached by *other*
-   * sessions — this is the authoritative, synchronous cap gate that closes the
-   * race between {@link canCreate} and the SDK's async session-initialized
-   * callback. Re-registering an existing session id is always allowed (it is an
-   * update, not growth).
+   * Register a freshly-initialized session. Returns false (and stores nothing)
+   * when the cap is already reached by *other* sessions: this synchronous check
+   * is the authoritative cap gate, closing the race between {@link canCreate}
+   * and the SDK's async session-initialized callback. Re-registering an existing
+   * id is an update, always allowed.
    */
   register(sessionId: string, transport: T): boolean {
     if (!this.entries.has(sessionId) && this.entries.size >= this.maxSessions) {
       return false;
     }
-    this.entries.set(sessionId, { transport, lastActivity: this.now() });
+    this.entries.set(sessionId, { transport, lastActivity: Date.now() });
     return true;
   }
 
-  /**
-   * Return the transport for a session, bumping its activity timestamp so an
-   * in-use session is never reaped by the idle sweep.
-   */
+  // Bumps lastActivity so an in-use session is never reaped by the idle sweep.
   get(sessionId: string): T | undefined {
     const entry = this.entries.get(sessionId);
     if (!entry) return undefined;
-    entry.lastActivity = this.now();
+    entry.lastActivity = Date.now();
     return entry.transport;
   }
 
-  /** Drop a session from the store. Safe to call for an unknown id. */
   delete(sessionId: string): void {
     this.entries.delete(sessionId);
   }
 
   /**
-   * Close and evict every session idle beyond the timeout. Returns the evicted
-   * session ids. Closing triggers the transport's own `onclose`, which also
-   * calls {@link delete}; deleting first here keeps that a harmless no-op.
+   * Close and evict every session idle beyond the timeout, returning the evicted
+   * ids. close() triggers the transport's own `onclose`, which also calls
+   * {@link delete}; evicting from the map first keeps that a harmless no-op.
    */
   sweepIdle(): string[] {
-    const cutoff = this.now() - this.idleTimeoutMs;
+    const cutoff = Date.now() - this.idleTimeoutMs;
     const stale: string[] = [];
     for (const [sessionId, entry] of this.entries) {
       if (entry.lastActivity <= cutoff) stale.push(sessionId);
@@ -117,23 +90,25 @@ export class HttpSessionStore<
       const entry = this.entries.get(sessionId);
       this.entries.delete(sessionId);
       if (!entry) continue;
-      // Defer the call so a synchronous throw also surfaces as a rejection, and
-      // route any failure to onSweepError rather than leaving it unhandled.
+      // Defer so a synchronous throw from close() also surfaces as a rejection
+      // rather than escaping this loop.
       void Promise.resolve()
         .then(() => entry.transport.close())
-        .catch((error) => this.onSweepError(error));
+        .catch((error) =>
+          console.error("[paperless-mcp] error closing idle session", error)
+        );
     }
     return stale;
   }
 
-  /** Start the periodic idle sweep. Idempotent; the timer never blocks exit. */
+  // Idempotent; unref() keeps the interval from holding the process open.
   startSweeper(): void {
     if (this.timer) return;
-    this.timer = setInterval(() => this.sweepIdle(), this.sweepIntervalMs);
+    const intervalMs = Math.min(this.idleTimeoutMs, 60 * 1000);
+    this.timer = setInterval(() => this.sweepIdle(), intervalMs);
     this.timer.unref?.();
   }
 
-  /** Stop the periodic idle sweep. */
   stopSweeper(): void {
     if (this.timer) {
       clearInterval(this.timer);

--- a/src/http/httpSessionStore.ts
+++ b/src/http/httpSessionStore.ts
@@ -18,6 +18,8 @@ export interface HttpSessionStoreOptions {
   sweepIntervalMs?: number;
   /** Injectable clock, for tests. */
   now?: () => number;
+  /** Called when a transport's close() rejects during an idle sweep. Defaults to console.error. */
+  onSweepError?: (error: unknown) => void;
 }
 
 interface SessionEntry<T> {
@@ -44,6 +46,7 @@ export class HttpSessionStore<
   private readonly idleTimeoutMs: number;
   private readonly sweepIntervalMs: number;
   private readonly now: () => number;
+  private readonly onSweepError: (error: unknown) => void;
   private timer?: ReturnType<typeof setInterval>;
 
   constructor(options: HttpSessionStoreOptions = {}) {
@@ -52,6 +55,10 @@ export class HttpSessionStore<
     this.sweepIntervalMs =
       options.sweepIntervalMs ?? Math.min(this.idleTimeoutMs, 60 * 1000);
     this.now = options.now ?? Date.now;
+    this.onSweepError =
+      options.onSweepError ??
+      ((error) =>
+        console.error("[paperless-mcp] error closing idle session", error));
   }
 
   get size(): number {
@@ -63,9 +70,20 @@ export class HttpSessionStore<
     return this.entries.size < this.maxSessions;
   }
 
-  /** Register a freshly-initialized session, stamping it active now. */
-  register(sessionId: string, transport: T): void {
+  /**
+   * Register a freshly-initialized session, stamping it active now. Returns
+   * false (and stores nothing) when the cap is already reached by *other*
+   * sessions — this is the authoritative, synchronous cap gate that closes the
+   * race between {@link canCreate} and the SDK's async session-initialized
+   * callback. Re-registering an existing session id is always allowed (it is an
+   * update, not growth).
+   */
+  register(sessionId: string, transport: T): boolean {
+    if (!this.entries.has(sessionId) && this.entries.size >= this.maxSessions) {
+      return false;
+    }
     this.entries.set(sessionId, { transport, lastActivity: this.now() });
+    return true;
   }
 
   /**
@@ -98,7 +116,12 @@ export class HttpSessionStore<
     for (const sessionId of stale) {
       const entry = this.entries.get(sessionId);
       this.entries.delete(sessionId);
-      void entry?.transport.close();
+      if (!entry) continue;
+      // Defer the call so a synchronous throw also surfaces as a rejection, and
+      // route any failure to onSweepError rather than leaving it unhandled.
+      void Promise.resolve()
+        .then(() => entry.transport.close())
+        .catch((error) => this.onSweepError(error));
     }
     return stale;
   }

--- a/src/http/httpSessionStore.ts
+++ b/src/http/httpSessionStore.ts
@@ -1,0 +1,120 @@
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+/**
+ * Minimal shape the store needs from a transport: something it can close when a
+ * session is evicted. Kept as an interface so the store is unit-testable with a
+ * fake transport (no real HTTP server required).
+ */
+export interface ClosableTransport {
+  close(): void | Promise<void>;
+}
+
+export interface HttpSessionStoreOptions {
+  /** Hard cap on concurrent sessions; new initialize requests are rejected above it. */
+  maxSessions?: number;
+  /** Sessions with no activity for this long (ms) are closed and evicted. */
+  idleTimeoutMs?: number;
+  /** How often (ms) the idle sweep runs. Defaults to min(idleTimeoutMs, 60s). */
+  sweepIntervalMs?: number;
+  /** Injectable clock, for tests. */
+  now?: () => number;
+}
+
+interface SessionEntry<T> {
+  transport: T;
+  lastActivity: number;
+}
+
+/**
+ * Bounded registry of stateful Streamable HTTP sessions.
+ *
+ * Without bounds the session map only shrinks when a transport closes cleanly
+ * (a client sending `DELETE /mcp` or dropping in a way the SDK detects). A
+ * client that abandons a session otherwise leaves its transport — and the
+ * `McpServer` connected to it — in memory for the process lifetime, and every
+ * initialize adds another. Under `--no-auth` that is an unauthenticated
+ * memory-exhaustion vector. This store caps concurrent sessions and reaps idle
+ * ones on an interval.
+ */
+export class HttpSessionStore<
+  T extends ClosableTransport = StreamableHTTPServerTransport
+> {
+  private readonly entries = new Map<string, SessionEntry<T>>();
+  private readonly maxSessions: number;
+  private readonly idleTimeoutMs: number;
+  private readonly sweepIntervalMs: number;
+  private readonly now: () => number;
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(options: HttpSessionStoreOptions = {}) {
+    this.maxSessions = options.maxSessions ?? 256;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? 30 * 60 * 1000;
+    this.sweepIntervalMs =
+      options.sweepIntervalMs ?? Math.min(this.idleTimeoutMs, 60 * 1000);
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** True when a new session may be created (concurrent cap not yet reached). */
+  canCreate(): boolean {
+    return this.entries.size < this.maxSessions;
+  }
+
+  /** Register a freshly-initialized session, stamping it active now. */
+  register(sessionId: string, transport: T): void {
+    this.entries.set(sessionId, { transport, lastActivity: this.now() });
+  }
+
+  /**
+   * Return the transport for a session, bumping its activity timestamp so an
+   * in-use session is never reaped by the idle sweep.
+   */
+  get(sessionId: string): T | undefined {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return undefined;
+    entry.lastActivity = this.now();
+    return entry.transport;
+  }
+
+  /** Drop a session from the store. Safe to call for an unknown id. */
+  delete(sessionId: string): void {
+    this.entries.delete(sessionId);
+  }
+
+  /**
+   * Close and evict every session idle beyond the timeout. Returns the evicted
+   * session ids. Closing triggers the transport's own `onclose`, which also
+   * calls {@link delete}; deleting first here keeps that a harmless no-op.
+   */
+  sweepIdle(): string[] {
+    const cutoff = this.now() - this.idleTimeoutMs;
+    const stale: string[] = [];
+    for (const [sessionId, entry] of this.entries) {
+      if (entry.lastActivity <= cutoff) stale.push(sessionId);
+    }
+    for (const sessionId of stale) {
+      const entry = this.entries.get(sessionId);
+      this.entries.delete(sessionId);
+      void entry?.transport.close();
+    }
+    return stale;
+  }
+
+  /** Start the periodic idle sweep. Idempotent; the timer never blocks exit. */
+  startSweeper(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.sweepIdle(), this.sweepIntervalMs);
+    this.timer.unref?.();
+  }
+
+  /** Stop the periodic idle sweep. */
+  stopSweeper(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,6 @@ async function main() {
 
         if (!transport) {
           if (sessionId || !isInitializeRequest(req.body)) {
-            // A non-initialize request must carry a known session id.
             res.status(400).json({
               jsonrpc: "2.0",
               error: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,15 @@ import {
   getBearerToken,
   sendUnauthorized,
 } from "./server";
+import { HttpSessionStore } from "./http/httpSessionStore";
 const { version } = require("../package.json") as { version: string };
+
+/** Parse a positive integer from a CLI/env string, falling back on anything invalid. */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 const {
   values: {
@@ -22,6 +30,8 @@ const {
     publicUrl,
     "no-auth": noAuth,
     stateful,
+    "max-sessions": maxSessionsArg,
+    "session-timeout": sessionTimeoutArg,
   },
 } = parseArgs({
   options: {
@@ -32,6 +42,8 @@ const {
     publicUrl: { type: "string", default: "" },
     "no-auth": { type: "boolean", default: false },
     stateful: { type: "boolean", default: false },
+    "max-sessions": { type: "string" },
+    "session-timeout": { type: "string" },
   },
   allowPositionals: true,
 });
@@ -41,10 +53,20 @@ const resolvedToken = token || process.env.PAPERLESS_API_KEY;
 const resolvedPublicUrl =
   publicUrl || process.env.PAPERLESS_PUBLIC_URL || resolvedBaseUrl;
 const resolvedPort = port ? parseInt(port, 10) : 3000;
+// Bounds for --stateful session tracking (CLI flag > env > default).
+const resolvedMaxSessions = parsePositiveInt(
+  maxSessionsArg ?? process.env.PAPERLESS_MCP_MAX_SESSIONS,
+  256
+);
+const resolvedSessionTimeoutMs =
+  parsePositiveInt(
+    sessionTimeoutArg ?? process.env.PAPERLESS_MCP_SESSION_TIMEOUT,
+    30 * 60
+  ) * 1000;
 
 if (!resolvedBaseUrl) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful] [--max-sessions <n>] [--session-timeout <seconds>]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
@@ -54,7 +76,7 @@ if (!resolvedBaseUrl) {
 
 if (!useHttp && !resolvedToken) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful] [--max-sessions <n>] [--session-timeout <seconds>]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
@@ -108,11 +130,17 @@ async function main() {
       // 2025-11-25 protocol — require a real session plus a server->client
       // notification stream, and drop a server that answers GET /mcp with 405.
       // Opt in with --stateful; the default remains the stateless handler below.
-      const httpTransports: Record<string, StreamableHTTPServerTransport> = {};
+      // The store caps concurrent sessions and reaps idle ones so an abandoned
+      // session (no DELETE /mcp) can't leak its transport for the process life.
+      const sessions = new HttpSessionStore({
+        maxSessions: resolvedMaxSessions,
+        idleTimeoutMs: resolvedSessionTimeoutMs,
+      });
+      sessions.startSweeper();
 
       app.post("/mcp", async (req, res) => {
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
-        let transport = sessionId ? httpTransports[sessionId] : undefined;
+        let transport = sessionId ? sessions.get(sessionId) : undefined;
 
         if (!transport) {
           if (sessionId || !isInitializeRequest(req.body)) {
@@ -137,15 +165,28 @@ async function main() {
             return;
           }
 
+          if (!sessions.canCreate()) {
+            // At the concurrent-session cap: refuse rather than grow unbounded.
+            res.status(503).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Server busy: too many active sessions",
+              },
+              id: null,
+            });
+            return;
+          }
+
           const newTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sid) => {
-              httpTransports[sid] = newTransport;
+              sessions.register(sid, newTransport);
             },
           });
           newTransport.onclose = () => {
             if (newTransport.sessionId) {
-              delete httpTransports[newTransport.sessionId];
+              sessions.delete(newTransport.sessionId);
             }
           };
           const server = buildServer(requestToken);
@@ -177,7 +218,7 @@ async function main() {
         res: express.Response
       ) => {
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
-        const transport = sessionId ? httpTransports[sessionId] : undefined;
+        const transport = sessionId ? sessions.get(sessionId) : undefined;
         if (!transport) {
           res.status(400).send("Invalid or missing session ID");
           return;
@@ -299,6 +340,12 @@ async function main() {
           stateful ? "Stateful" : "Stateless"
         } Streamable HTTP Server listening on port ${resolvedPort}`
       );
+      if (stateful) {
+        console.log(
+          `[paperless-mcp] session bounds: max ${resolvedMaxSessions}, ` +
+            `idle timeout ${resolvedSessionTimeoutMs / 1000}s`
+        );
+      }
     });
     // await new Promise((resolve) => setTimeout(resolve, 1000000));
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import express from "express";
+import { randomUUID } from "node:crypto";
 import { parseArgs } from "node:util";
 import {
   createMcpServer,
@@ -12,7 +14,15 @@ import {
 const { version } = require("../package.json") as { version: string };
 
 const {
-  values: { baseUrl, token, http: useHttp, port, publicUrl, "no-auth": noAuth },
+  values: {
+    baseUrl,
+    token,
+    http: useHttp,
+    port,
+    publicUrl,
+    "no-auth": noAuth,
+    stateful,
+  },
 } = parseArgs({
   options: {
     baseUrl: { type: "string" },
@@ -21,6 +31,7 @@ const {
     port: { type: "string" },
     publicUrl: { type: "string", default: "" },
     "no-auth": { type: "boolean", default: false },
+    stateful: { type: "boolean", default: false },
   },
   allowPositionals: true,
 });
@@ -33,7 +44,7 @@ const resolvedPort = port ? parseInt(port, 10) : 3000;
 
 if (!resolvedBaseUrl) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
@@ -43,7 +54,7 @@ if (!resolvedBaseUrl) {
 
 if (!useHttp && !resolvedToken) {
   console.error(
-    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth]"
+    "Usage: paperless-mcp --baseUrl <url> --token <token> [--http] [--port <port>] [--publicUrl <url>] [--no-auth] [--stateful]"
   );
   console.error(
     "Or set PAPERLESS_URL and PAPERLESS_API_KEY environment variables."
@@ -91,65 +102,152 @@ async function main() {
     // Store transports for each session
     const sseTransports: Record<string, SSEServerTransport> = {};
 
-    app.post("/mcp", async (req, res) => {
-      const requestToken = getBearerToken(req, {
-        fallbackToken: resolvedToken,
-        allowAnonymous: noAuth,
+    if (stateful) {
+      // Stateful Streamable HTTP: one transport + server per session, keyed by
+      // Mcp-Session-Id. Some clients — notably MCP gateways that negotiate the
+      // 2025-11-25 protocol — require a real session plus a server->client
+      // notification stream, and drop a server that answers GET /mcp with 405.
+      // Opt in with --stateful; the default remains the stateless handler below.
+      const httpTransports: Record<string, StreamableHTTPServerTransport> = {};
+
+      app.post("/mcp", async (req, res) => {
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+        let transport = sessionId ? httpTransports[sessionId] : undefined;
+
+        if (!transport) {
+          if (sessionId || !isInitializeRequest(req.body)) {
+            // A non-initialize request must carry a known session id.
+            res.status(400).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32000,
+                message: "Bad Request: No valid session ID provided",
+              },
+              id: null,
+            });
+            return;
+          }
+
+          const requestToken = getBearerToken(req, {
+            fallbackToken: resolvedToken,
+            allowAnonymous: noAuth,
+          });
+          if (!requestToken) {
+            sendUnauthorized(res);
+            return;
+          }
+
+          const newTransport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (sid) => {
+              httpTransports[sid] = newTransport;
+            },
+          });
+          newTransport.onclose = () => {
+            if (newTransport.sessionId) {
+              delete httpTransports[newTransport.sessionId];
+            }
+          };
+          const server = buildServer(requestToken);
+          await server.connect(newTransport);
+          transport = newTransport;
+        }
+
+        try {
+          await transport.handleRequest(req, res, req.body);
+        } catch (error) {
+          console.error("Error handling MCP request:", error);
+          if (!res.headersSent) {
+            res.status(500).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32603,
+                message: "Internal server error",
+              },
+              id: null,
+            });
+          }
+        }
       });
-      if (!requestToken) {
-        sendUnauthorized(res);
-        return;
-      }
-      try {
-        const server = buildServer(requestToken);
-        const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined,
+
+      // GET (server->client notification stream) and DELETE (session teardown)
+      // are served from the existing session's transport.
+      const handleSessionRequest = async (
+        req: express.Request,
+        res: express.Response
+      ) => {
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+        const transport = sessionId ? httpTransports[sessionId] : undefined;
+        if (!transport) {
+          res.status(400).send("Invalid or missing session ID");
+          return;
+        }
+        await transport.handleRequest(req, res);
+      };
+
+      app.get("/mcp", handleSessionRequest);
+      app.delete("/mcp", handleSessionRequest);
+    } else {
+      app.post("/mcp", async (req, res) => {
+        const requestToken = getBearerToken(req, {
+          fallbackToken: resolvedToken,
+          allowAnonymous: noAuth,
         });
-        res.on("close", () => {
-          transport.close();
-        });
-        await server.connect(transport);
-        await transport.handleRequest(req, res, req.body);
-      } catch (error) {
-        console.error("Error handling MCP request:", error);
-        if (!res.headersSent) {
-          res.status(500).json({
+        if (!requestToken) {
+          sendUnauthorized(res);
+          return;
+        }
+        try {
+          const server = buildServer(requestToken);
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+          });
+          res.on("close", () => {
+            transport.close();
+          });
+          await server.connect(transport);
+          await transport.handleRequest(req, res, req.body);
+        } catch (error) {
+          console.error("Error handling MCP request:", error);
+          if (!res.headersSent) {
+            res.status(500).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32603,
+                message: "Internal server error",
+              },
+              id: null,
+            });
+          }
+        }
+      });
+
+      app.get("/mcp", async (req, res) => {
+        res.writeHead(405).end(
+          JSON.stringify({
             jsonrpc: "2.0",
             error: {
-              code: -32603,
-              message: "Internal server error",
+              code: -32000,
+              message: "Method not allowed.",
             },
             id: null,
-          });
-        }
-      }
-    });
+          })
+        );
+      });
 
-    app.get("/mcp", async (req, res) => {
-      res.writeHead(405).end(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Method not allowed.",
-          },
-          id: null,
-        })
-      );
-    });
-
-    app.delete("/mcp", async (req, res) => {
-      res.writeHead(405).end(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Method not allowed.",
-          },
-          id: null,
-        })
-      );
-    });
+      app.delete("/mcp", async (req, res) => {
+        res.writeHead(405).end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message: "Method not allowed.",
+            },
+            id: null,
+          })
+        );
+      });
+    }
 
     app.get("/sse", async (req, res) => {
       console.log("SSE request received");
@@ -197,7 +295,9 @@ async function main() {
 
     app.listen(resolvedPort, () => {
       console.log(
-        `MCP Stateless Streamable HTTP Server listening on port ${resolvedPort}`
+        `MCP ${
+          stateful ? "Stateful" : "Stateless"
+        } Streamable HTTP Server listening on port ${resolvedPort}`
       );
     });
     // await new Promise((resolve) => setTimeout(resolve, 1000000));

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,12 @@ async function main() {
           const newTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sid) => {
-              sessions.register(sid, newTransport);
+              // register() is the authoritative cap gate; the canCreate() check
+              // above is only a fast reject. If a concurrent initialize claimed
+              // the last slot in between, tear this excess session back down.
+              if (!sessions.register(sid, newTransport)) {
+                void newTransport.close();
+              }
             },
           });
           newTransport.onclose = () => {


### PR DESCRIPTION
Closes #154

## Summary

Adds an opt-in `--stateful` flag that switches the HTTP server's `/mcp` endpoint from the current stateless Streamable HTTP transport to the standard SDK stateful pattern. **The default is unchanged**, so this is backward-compatible.

## Motivation

Today the HTTP server is stateless: it builds a `StreamableHTTPServerTransport` with `sessionIdGenerator: undefined` per POST and answers `GET`/`DELETE /mcp` with `405`. That works for clients that drive everything over POST, but a client that negotiates the **2025-11-25** protocol — e.g. an MCP gateway aggregating upstream servers — expects a real session (`Mcp-Session-Id`) plus a server→client notification stream over `GET /mcp`, and drops a server that 405s the GET. With SDK ≥1.30 negotiating 2025-11-25 natively, such a client discovers paperless-mcp's tools but can't actually use it.

## Change

With `--stateful`:
- `POST /mcp` creates one `StreamableHTTPServerTransport` per session (keyed by `Mcp-Session-Id`, `sessionIdGenerator: randomUUID`), reused across requests; a non-initialize request without a known session gets `400`.
- `GET /mcp` serves the notification stream; `DELETE /mcp` tears the session down; sessions are cleaned up on transport close.

Without the flag the existing stateless handlers run verbatim. The `--no-auth` / bearer-token handling and the SSE (`/sse`, `/messages`) endpoints are untouched.

## Testing

- `npm test` — 57/57 pass (incl. the #138 array-form regression test).
- Manual, both modes:
  - **default (stateless):** `initialize` → 200 with no session id; `GET /mcp` → 405 (unchanged).
  - **`--stateful`:** `initialize` → 200, negotiates `2025-11-25`, issues a session id; `GET /mcp` → 200 stream; `tools/list` → all 44 tools.
- Verified end-to-end against a Kuadrant MCP gateway: with `--stateful` the server federates and all 44 tools are served.

Context: #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional stateful Streamable HTTP sessions with session identifiers and support for follow-up `GET` and `DELETE` requests.
  * Added configurable session limits and idle-session cleanup through command-line options and environment variables.
  * Updated usage guidance and startup status to indicate whether stateful or stateless mode is active.

* **Compatibility**
  * Stateless mode remains the default and retains its existing request behavior.
  * Stateful mode reports clear errors for missing or invalid sessions and when capacity is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
