### PR TITLE
Move typescript to devDependencies

### DIFF
--- a/.changeset/typescript-devdependency.md
+++ b/.changeset/typescript-devdependency.md
@@ -1,0 +1,7 @@
+---
+"@baruchiro/paperless-mcp": patch
+---
+
+Move `typescript` from `dependencies` to `devDependencies`
+
+The compiled entrypoint (`build/index.js`) doesn't need the TypeScript compiler at runtime, but it was declared as a production dependency, so it shipped in the production container image even after pruning devDependencies. It now stays out of a `--omit=dev` install.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@baruchiro/paperless-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baruchiro/paperless-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.9.0",
         "express": "^5.1.0",
         "form-data": "^4.0.2",
-        "typescript": "^5.8.3",
         "zod": "~4.4.3"
       },
       "bin": {
@@ -24,7 +23,8 @@
         "@changesets/cli": "^2.29.4",
         "@types/express": "^5.0.2",
         "@types/node": "^24.0.0",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -3083,6 +3083,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "axios": "^1.9.0",
     "express": "^5.1.0",
     "form-data": "^4.0.2",
-    "typescript": "^5.8.3",
     "zod": "~4.4.3"
   },
   "devDependencies": {
@@ -56,6 +55,7 @@
     "@changesets/cli": "^2.29.4",
     "@types/express": "^5.0.2",
     "@types/node": "^24.0.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## Summary

- `typescript` was declared under `dependencies` even though the compiled entrypoint (`build/index.js`) never needs the compiler at runtime — only `tsc` at build time.
- Because of that classification, it survived `npm prune --omit=dev` / a `npm ci --omit=dev` production install and shipped in the container image unnecessarily (see #143, which noted this as a follow-up).
- Moved `typescript` to `devDependencies`, alongside `ts-node` which already depends on it.

## Testing

- `npm install` to regenerate `package-lock.json` — the only functional change in the lockfile is `typescript` gaining `"dev": true`.
- `npm run build` still passes.
- Verified with a clean `npm ci --omit=dev` install that `node_modules` no longer contains `typescript`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHvCMRaPdWZKNkiRLT7HuL


---
_Generated by [Claude Code](https://claude.ai/code/session_01JHvCMRaPdWZKNkiRLT7HuL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Production installations are now slimmer by excluding development-only tooling that isn’t needed at runtime.
  * Runtime validation support is now included where required, improving reliability in production environments.
* **Chores**
  * Updated package release metadata to reflect these packaging improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->